### PR TITLE
file locking for reading and writing the GA config file, closes #114

### DIFF
--- a/bizarro/google_access_token_update.py
+++ b/bizarro/google_access_token_update.py
@@ -2,6 +2,7 @@ from logging import getLogger
 Logger = getLogger('bizarro.google_access_token_update')
 
 from .google_api_functions import get_new_access_token, GA_CONFIG_FILENAME
+from .view_functions import ReadLocked
 import json
 import os
 import argparse
@@ -24,7 +25,7 @@ if __name__ == '__main__':
     while True:
         try:
             ga_config_path = os.path.join(os.environ['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
-            with open(ga_config_path) as infile:
+            with ReadLocked(ga_config_path) as infile:
                 ga_config = json.load(infile)
             get_new_access_token(ga_config['refresh_token'])
         except:

--- a/bizarro/views.py
+++ b/bizarro/views.py
@@ -14,7 +14,7 @@ from flask import redirect, request, Response, render_template, session, current
 from . import bizarro as app
 from . import repo_functions, edit_functions
 from .jekyll_functions import load_jekyll_doc, build_jekyll_site, load_languages
-from .view_functions import (branch_name2path, branch_var2name, get_repo, name_branch, dos2unix,
+from .view_functions import (ReadLocked, branch_name2path, branch_var2name, get_repo, name_branch, dos2unix,
                              login_required, synch_required, synched_checkout_required, is_editable,
                              sorted_paths, directory_paths, should_redirect, make_redirect)
 from .google_api_functions import authorize_google, callback_google, fetch_google_analytics_for_page, GA_CONFIG_FILENAME
@@ -275,7 +275,7 @@ def branch_edit(branch, path=None):
         ga_config_path = posixpath.join(current_app.config['RUNNING_STATE_DIR'], GA_CONFIG_FILENAME)
         analytics_dict = {}
         if isfile(ga_config_path):
-            with open(ga_config_path) as infile:
+            with ReadLocked(ga_config_path) as infile:
                 ga_config = json.load(infile)
 
             if ga_config['access_token']:

--- a/test/test.py
+++ b/test/test.py
@@ -884,7 +884,8 @@ class TestGoogleApiFunctions (TestCase):
             "profile_id": "12345678",
             "project_domain": ""
         }
-        with open(ga_config_path, 'w') as outfile:
+        with view_functions.WriteLocked(ga_config_path) as outfile:
+            outfile.truncate(0)
             json.dump(ga_config, outfile, indent=2, ensure_ascii=False)
 
     def tearDown(self):
@@ -921,7 +922,7 @@ class TestGoogleApiFunctions (TestCase):
                 google_api_functions.get_new_access_token('meowser_refresh_token')
 
                 ga_config_path = os.path.join(self.app.config['RUNNING_STATE_DIR'], google_api_functions.GA_CONFIG_FILENAME)
-                with open(ga_config_path) as infile:
+                with view_functions.ReadLocked(ga_config_path) as infile:
                     ga_config = json.load(infile)
 
                 self.assertEqual(ga_config['access_token'], 'meowser_access_token')
@@ -1008,7 +1009,8 @@ class TestApp (TestCase):
             "profile_id": "12345678",
             "project_domain": ""
         }
-        with open(ga_config_path, 'w') as outfile:
+        with view_functions.WriteLocked(ga_config_path) as outfile:
+            outfile.truncate(0)
             json.dump(ga_config, outfile, indent=2, ensure_ascii=False)
 
         random.choice = MagicMock(return_value="P")
@@ -1139,7 +1141,7 @@ class TestApp (TestCase):
             response = self.server.get('/callback?state=PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP&code=code')
 
         ga_config_path = os.path.join(self.app.config['RUNNING_STATE_DIR'], google_api_functions.GA_CONFIG_FILENAME)
-        with open(ga_config_path) as infile:
+        with view_functions.ReadLocked(ga_config_path) as infile:
             ga_config = json.load(infile)
 
         self.assertEqual(ga_config['access_token'], 'meowser_token')


### PR DESCRIPTION
Created new WriteLocked and ReadLocked classes to manage the context of file operations, specifically with the Google Analytics config file. Put it in use everywhere that the config file was being touched.
