### PR TITLE
Enforce category site structure #216

### DIFF
--- a/chime/edit_functions.py
+++ b/chime/edit_functions.py
@@ -16,7 +16,7 @@ def update_page(clone, file_path, front, body):
     with open(full_path, 'w') as file:
         dump_jekyll_doc(front, body, file)
 
-def create_path_to_page(clone, dir_path, file_path, front, body, index_filename):
+def create_path_to_page(clone, dir_path, file_path, front, body, filename):
     ''' Build non-existing directories in file_path as category directories.
     '''
     # Build a full directory path.
@@ -30,8 +30,12 @@ def create_path_to_page(clone, dir_path, file_path, front, body, index_filename)
         raise Exception('Invalid path component.')
 
     # Build the category directory tree.
+    file_paths = []
     for i in range(len(dirs)):
-        create_new_page(clone, dir_path, join(sep.join(dirs[:i + 1]), index_filename), front, body)
+        file_path = create_new_page(clone, dir_path, join(sep.join(dirs[:i + 1]), filename), front, body)
+        file_paths.append(file_path)
+
+    return file_paths
 
 def create_new_page(clone, dir_path, file_path, front, body):
     ''' Create a new Jekyll page in the working directory, return its path.

--- a/chime/edit_functions.py
+++ b/chime/edit_functions.py
@@ -1,5 +1,5 @@
 
-from os.path import exists, isdir, join
+from os.path import exists, isdir, join, split, sep
 from os import rmdir, remove
 
 import repo_functions
@@ -16,10 +16,27 @@ def update_page(clone, file_path, front, body):
     with open(full_path, 'w') as file:
         dump_jekyll_doc(front, body, file)
 
-def create_new_page(clone, path, file_name, front, body):
+def create_path_to_page(clone, dir_path, file_path, front, body, index_filename):
+    ''' Build non-existing directories in file_path as category directories.
+    '''
+    # Build a full directory path.
+    head, dirs = split(file_path)[0], []
+
+    while head:
+        head, check_dir = split(head)
+        dirs.insert(0, check_dir)
+
+    if '..' in dirs:
+        raise Exception('Invalid path component.')
+
+    # Build the category directory tree.
+    for i in range(len(dirs)):
+        create_new_page(clone, dir_path, join(sep.join(dirs[:i + 1]), index_filename), front, body)
+
+def create_new_page(clone, dir_path, file_path, front, body):
     ''' Create a new Jekyll page in the working directory, return its path.
     '''
-    file_path, full_path = repo_functions.make_working_file(clone, path, file_name)
+    file_path, full_path = repo_functions.make_working_file(clone, dir_path, file_path)
 
     if exists(full_path):
         raise Exception(u'create_new_page: path already exists!')

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -1,9 +1,8 @@
 # -- coding: utf-8 --
 from __future__ import absolute_import
-import os
 import logging
 from os import mkdir
-from os.path import join, split, exists, isdir
+from os.path import join, split, exists, isdir, sep
 from itertools import chain
 from git.cmd import GitCommandError
 import hashlib
@@ -398,13 +397,13 @@ def make_working_file(clone, dir, path):
         dirs.insert(0, dir)
 
     if '..' in dirs:
-        raise Exception('None of that now')
+        raise Exception('Invalid path component.')
 
     #
     # Create directory tree.
     #
     for i in range(len(dirs)):
-        dir_path = join(clone.working_dir, os.sep.join(dirs[:i + 1]))
+        dir_path = join(clone.working_dir, sep.join(dirs[:i + 1]))
 
         if not isdir(dir_path):
             mkdir(dir_path)

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -386,7 +386,7 @@ def make_working_file(clone, dir, path):
                include existing or new directories
     '''
     repo_path = join((dir or '').rstrip('/'), path)
-    real_path = join(clone.working_dir, repo_path)
+    full_path = join(clone.working_dir, repo_path)
 
     #
     # Build a full directory path.
@@ -409,7 +409,7 @@ def make_working_file(clone, dir, path):
         if not isdir(dir_path):
             mkdir(dir_path)
 
-    return repo_path, real_path
+    return repo_path, full_path
 
 def sync_with_default_and_upstream_branches(clone, sync_branch_name):
     ''' Sync the passed branch with default and upstream branches.

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -373,18 +373,18 @@ def clobber_default_branch(clone, default_branch_name, working_branch_name):
     clone.remotes.origin.push(':' + working_branch_name)
     clone.delete_head([working_branch_name])
 
-def make_working_file(clone, dir, path):
+def make_working_file(clone, dir_path, file_path):
     ''' Determine the relative and absolute location of a new file, create
         any directories in its path that don't already exist, and return
         its local git and real absolute paths. Does not create the actual
         file.
 
-        `dir` is the existing directory the file is being created in
+        `dir_path` is the existing directory the file is being created in
 
-        `path` is the path that was entered to create the file, which may
-               include existing or new directories
+        `file_path` is the path that was entered to create the file, which
+                    may include existing or new directories
     '''
-    repo_path = join((dir or '').rstrip('/'), path)
+    repo_path = join((dir_path or '').rstrip('/'), file_path)
     full_path = join(clone.working_dir, repo_path)
 
     #
@@ -393,8 +393,8 @@ def make_working_file(clone, dir, path):
     head, dirs = split(repo_path)[0], []
 
     while head:
-        head, dir = split(head)
-        dirs.insert(0, dir)
+        head, check_dir = split(head)
+        dirs.insert(0, check_dir)
 
     if '..' in dirs:
         raise Exception('Invalid path component.')
@@ -403,10 +403,10 @@ def make_working_file(clone, dir, path):
     # Create directory tree.
     #
     for i in range(len(dirs)):
-        dir_path = join(clone.working_dir, sep.join(dirs[:i + 1]))
+        build_path = join(clone.working_dir, sep.join(dirs[:i + 1]))
 
-        if not isdir(dir_path):
-            mkdir(dir_path)
+        if not isdir(build_path):
+            mkdir(build_path)
 
     return repo_path, full_path
 

--- a/chime/templates/articles-list.html
+++ b/chime/templates/articles-list.html
@@ -76,6 +76,19 @@
     </div>
     <div class="grid__item width-two-thirds end-row">
         <table class="files">
+            <tbody>
+                <tr>
+                    {% for dir in dir_columns %}
+                    <td>
+                        {% for file in dir %}
+                        {% if file['selected'] == True %}<strong>{% endif %}<a href="{{file['edit_path']}}">{{file['name']}}</a> ({{file['display_type']}}){% if file['selected'] == True %}</strong>{% endif %}<br />
+                        {% endfor %}
+                    </td>
+                    {% endfor %}
+                </tr>
+            </tbody>
+        </table>
+        <table class="files">
             <thead>
                 <tr>
                     <th colspan="4">

--- a/chime/templates/articles-list.html
+++ b/chime/templates/articles-list.html
@@ -96,13 +96,11 @@
                 {% for (edit_path, view_path, item_type, is_editable, modified_date) in list_paths %}
                 <form action="." method="POST">
                 <tr>
-                    <td><a class="{{ item_type }}" href="{{edit_path}}">{{edit_path}}</a>
-                        
+                    <td>
+                        <a class="{{item_type}}" href="{{edit_path}}">{% if item_type == "file" and not is_editable %}<em>{{edit_path}}</em>{% else %}{{edit_path}}{% endif %}</a>
                     </td>
                     <td>
-                        {%if item_type == "folder" %}folder{% endif %}
-                        {%if item_type == "file" and is_editable %}file{% endif %}
-                        {%if item_type == "image" %}image{% endif %}
+                        {% if item_type == "file" and not is_editable %}<em>file</em>{% else %}{{item_type}}{% endif %}
                     </td>
                     <td>
                         {%if item_type == "file" or item_type == "image" %}<span>{{modified_date}}</span>{% endif %}

--- a/chime/templates/articles-list.html
+++ b/chime/templates/articles-list.html
@@ -103,11 +103,11 @@
                         {% if item_type == "file" and not is_editable %}<em>file</em>{% else %}{{item_type}}{% endif %}
                     </td>
                     <td>
-                        {%if item_type == "file" or item_type == "image" %}<span>{{modified_date}}</span>{% endif %}
+                        <span>{{modified_date}}</span>
                     </td>
                     <td>
-                        {%if item_type == "file" and is_editable %}<a href="{{edit_path}}" class="button" ><img src="/static/images/icons/ionicons/png/512/edit.png" height="20px" alt="Edit" title="Edit" /></a>{% endif %}
-                        {%if item_type == "file" or item_type == "image" %}<a href="{{view_path}}" class="button" target="_blank"><img src="/static/images/icons/ionicons/png/512/eye.png" height="20px" alt="Preview" title="Preview" /></a>{% endif %}
+                        {%if is_editable %}<a href="{{edit_path}}" class="button" ><img src="/static/images/icons/ionicons/png/512/edit.png" height="20px" alt="Edit" title="Edit" /></a>{% endif %}
+                        <a href="{{view_path}}" class="button" target="_blank"><img src="/static/images/icons/ionicons/png/512/eye.png" height="20px" alt="Preview" title="Preview" /></a>
                         
                         <button name="action" type="submit" value="Delete" class="button button--red"><img src="/static/images/icons/ionicons/png/512/trash-a.png" alt="Archive" title="Archive" height="20px" style="color:red;" /></button>
                     </td>

--- a/chime/templates/articles-list.html
+++ b/chime/templates/articles-list.html
@@ -117,11 +117,20 @@
                 {% endfor %}  
                     
                     <tr>
-                        <td><b>Create new page<b></td>
+                        <td><b>Create new article<b></td>
                         <td colspan="3">
                             <form action="." method="POST">
                                 <input name="path" placeholder="article name" type="text" />
-                                <input name="action" type="submit" value="Add" />
+                                <input name="action" type="submit" value="Add Article" />
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><b>Create new category<b></td>
+                        <td colspan="3">
+                            <form action="." method="POST">
+                                <input name="path" placeholder="category name" type="text" />
+                                <input name="action" type="submit" value="Add Category" />
                             </form>
                         </td>
                     </tr>

--- a/chime/templates/tree-branch-edit-listdir.html
+++ b/chime/templates/tree-branch-edit-listdir.html
@@ -5,7 +5,7 @@
 <div class="main-content">
     <div class="file-explorer">
         <h2>Task</h2>
-        <p>This is your work area. Here you can navigate to the content you want to edit, upload images or create new pages.</p>
+        <p>This is your work area. Here you can navigate to the content you want to edit, upload images or create new articles.</p>
         <div class="task-status">
                 {% set itemvalues = branch.split('/') %}
                 {% set name = itemvalues[0] %}
@@ -119,10 +119,10 @@
                 {% endfor %}  
                     
                     <tr>
-                        <th>Create new page</th>
+                        <th>Create new article</th>
                         <td colspan="3">
                             <form action="." method="POST">
-                                <input name="path" placeholder="page name" type="text" />
+                                <input name="path" placeholder="article name" type="text" />
                                 <input name="action" type="submit" value="Add" />
                             </form>
                         </td>

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -535,7 +535,7 @@ def directory_paths(branch_name, path=None):
 
 def directory_columns(clone, branch_name, repo_path=None):
     ''' Get a list of lists of dicts for the passed path, with file listings for each level.
-        example: passing 'hello/world' will return something like:
+        example: passing 'hello/world/wide' will return something like:
             [
                 [
                     {'name': 'hello', 'edit_path': '/tree/8bf27f6/edit/hello', 'display_type': 'category', 'selected': True},

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -144,6 +144,9 @@ def path_display_type(file_path):
     if is_article_dir(file_path):
         return 'article'
 
+    if is_category_dir(file_path):
+        return 'category'
+
     return path_type(file_path)
 
 # ONLY CALLED FROM sorted_paths()

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -162,7 +162,7 @@ def is_article_dir(file_path):
     return is_dir_with_layout(file_path, ARTICLE_LAYOUT, True)
 
 def is_category_dir(file_path):
-    ''' Returns True if the file at the passed path is a directory containing only an index file with a category jekyll layout.
+    ''' Returns True if the file at the passed path is a directory containing an index file with a category jekyll layout.
     '''
     return is_dir_with_layout(file_path, CATEGORY_LAYOUT, False)
 
@@ -202,9 +202,13 @@ def is_dir_with_layout(file_path, layout, only=True):
             # there's no index file in the directory or it's not editable
             return False
 
+        if not only:
+            # it doesn't matter how many files are in the directory
+            return True
+
         visible_file_count = len([name for name in listdir(file_path) if not FILE_FILTERS_COMPILED.search(name)])
-        if visible_file_count == 0 or not only:
-            # there's only an index file in the directory or multiple files are okay
+        if visible_file_count == 0:
+            # there's only an index file in the directory
             return True
 
     # it's not a directory

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -28,7 +28,6 @@ from fcntl import flock, LOCK_EX, LOCK_UN, LOCK_SH
 # files that match these regex patterns will not be shown in the file explorer
 CONTENT_FILE_EXTENSION = u'markdown'
 CATEGORY_LAYOUT = 'category'
-SUBCATEGORY_LAYOUT = 'subcategory'
 ARTICLE_LAYOUT = 'article'
 FILE_FILTERS = [
     r'^\.',
@@ -147,6 +146,14 @@ def path_display_type(file_path):
 
     return path_type(file_path)
 
+# ONLY CALLED FROM sorted_paths()
+def is_display_editable(file_path, layout=None):
+    ''' Returns True if the file at the passed path is either an editable file,
+        or a directory containing only an editable index file.
+    '''
+    # :NOTE: not sending the layout to is_editable keeps legacy files editable
+    return (is_editable(file_path) or is_editable_dir(file_path, layout))
+
 def is_editable_dir(file_path, layout=None):
     ''' Returns true if the file at the passed path is a directory containing only an editable index file with the passed jekyll layout.
     '''
@@ -165,13 +172,7 @@ def is_editable_dir(file_path, layout=None):
     # it's not a directory
     return False
 
-def is_display_editable(file_path, layout=None):
-    ''' Returns True if the file at the passed path is either an editable file,
-        or a directory containing only an editable index file.
-    '''
-    # not sending the layout to is_editable keeps legacy files editable
-    return (is_editable(file_path) or is_editable_dir(file_path, layout))
-
+# ONLY CALLED FROM THE TWO FUNCTIONS ABOVE
 def is_editable(file_path, layout=None):
     ''' Returns True if the file at the passed path is not a directory, and has jekyll
         front matter with the passed layout.

--- a/chime/views.py
+++ b/chime/views.py
@@ -19,7 +19,7 @@ from .view_functions import (
     branch_name2path, branch_var2name, get_repo, dos2unix,
     login_required, browserid_hostname_required, synch_required, synched_checkout_required, sorted_paths,
     directory_paths, should_redirect, make_redirect, get_auth_data_file,
-    is_allowed_email, common_template_args, is_editable_dir, CONTENT_FILE_EXTENSION)
+    is_allowed_email, common_template_args, is_editable_dir, CONTENT_FILE_EXTENSION, ARTICLE_LAYOUT)
 from .google_api_functions import (
     read_ga_config, write_ga_config, request_new_google_access_and_refresh_tokens,
     authorize_google, get_google_personal_info, get_google_analytics_properties,
@@ -453,7 +453,7 @@ def branch_edit(branch, path=None):
 
     if isdir(full_path):
         # if this is an editable directory (contains only an editable index file), redirect
-        if is_editable_dir(full_path):
+        if is_editable_dir(full_path, ARTICLE_LAYOUT):
             index_path = join(path or u'', u'index.{}'.format(CONTENT_FILE_EXTENSION))
             return redirect('/tree/{}/edit/{}'.format(branch_name2path(branch), index_path))
 
@@ -486,7 +486,7 @@ def branch_edit_file(branch, path=None):
     elif action == 'add' and 'path' in request.form:
         name = u'{}/index.{}'.format(splitext(request.form['path'])[0], CONTENT_FILE_EXTENSION)
 
-        front, body = dict(title=u'', layout='default'), u''
+        front, body = dict(title=u'', layout=ARTICLE_LAYOUT), u''
         file_path = edit_functions.create_new_page(r, path, name, front, body)
         message = 'Created new file "%s"' % file_path
         path_303 = file_path
@@ -640,7 +640,7 @@ def branch_save(branch, path):
 
             path = new_slug
             # append the index file if it's an editable directory
-            if is_editable_dir(join(repo.working_dir, new_slug)):
+            if is_editable_dir(join(repo.working_dir, new_slug), ARTICLE_LAYOUT):
                 path = join(new_slug, u'index.{}'.format(CONTENT_FILE_EXTENSION))
 
     except repo_functions.MergeConflict as conflict:

--- a/chime/views.py
+++ b/chime/views.py
@@ -507,7 +507,7 @@ def branch_edit_file(branch, path=None):
 
         front, body = dict(title=u'', layout=ARTICLE_LAYOUT), u''
         file_path = edit_functions.create_new_page(r, path, name, front, body)
-        message = 'Created new page "%s"' % file_path
+        message = 'Created new article "%s"' % file_path
         redirect_path = file_path
 
     elif action == 'add category' and 'path' in request.form:

--- a/chime/views.py
+++ b/chime/views.py
@@ -425,8 +425,7 @@ def render_edit_view(repo, branch, path, file):
     languages = load_languages(repo.working_dir)
     url_slug = path
     # strip the index file from the slug if appropriate
-    if search(r'\/index.{}$'.format(CONTENT_FILE_EXTENSION), path):
-        url_slug = sub(ur'index.{}$'.format(CONTENT_FILE_EXTENSION), u'', url_slug)
+    url_slug = sub(ur'index.{}$'.format(CONTENT_FILE_EXTENSION), u'', url_slug)
     view_path = join('/tree/{}/view'.format(branch_name2path(branch)), path)
     history_path = join('/tree/{}/history'.format(branch_name2path(branch)), path)
     task_root_path = u'/tree/{}/edit/'.format(branch_name2path(branch))

--- a/chime/views.py
+++ b/chime/views.py
@@ -21,7 +21,7 @@ from .view_functions import (
     login_required, browserid_hostname_required, synch_required, synched_checkout_required, sorted_paths,
     directory_paths, should_redirect, make_redirect, get_auth_data_file,
     is_allowed_email, common_template_args, log_application_errors,
-    is_editable_dir, CONTENT_FILE_EXTENSION, ARTICLE_LAYOUT)
+    is_article_dir, CONTENT_FILE_EXTENSION, ARTICLE_LAYOUT)
 
 from .google_api_functions import (
     read_ga_config, write_ga_config, request_new_google_access_and_refresh_tokens,
@@ -471,7 +471,7 @@ def branch_edit(branch, path=None):
 
     if isdir(full_path):
         # if this is an editable directory (contains only an editable index file), redirect
-        if is_editable_dir(full_path, ARTICLE_LAYOUT):
+        if is_article_dir(full_path):
             index_path = join(path or u'', u'index.{}'.format(CONTENT_FILE_EXTENSION))
             return redirect('/tree/{}/edit/{}'.format(branch_name2path(branch), index_path))
 
@@ -662,7 +662,7 @@ def branch_save(branch, path):
 
             path = new_slug
             # append the index file if it's an editable directory
-            if is_editable_dir(join(repo.working_dir, new_slug), ARTICLE_LAYOUT):
+            if is_article_dir(join(repo.working_dir, new_slug)):
                 path = join(new_slug, u'index.{}'.format(CONTENT_FILE_EXTENSION))
 
     except repo_functions.MergeConflict as conflict:

--- a/test/test.py
+++ b/test/test.py
@@ -1582,7 +1582,7 @@ class TestApp (TestCase):
             hexsha = search(r'<input name="hexsha" value="(\w+)"', response.data).group(1)
             # now save the file with new content
             response = self.test_client.post('/tree/{}/save/{}'.format(generated_branch_name, fake_page_path),
-                                             data={'layout': 'multi', 'hexsha': hexsha,
+                                             data={'layout': view_functions.ARTICLE_LAYOUT, 'hexsha': hexsha,
                                                    'en-title': 'Greetings',
                                                    'en-body': u'{}\n'.format(fake_page_content),
                                                    'fr-title': '', 'fr-body': '',
@@ -1727,7 +1727,7 @@ class TestApp (TestCase):
             self.assertEquals(response.status_code, 200)
             self.assertFalse(generated_branch_name in response.data)
 
-            response = self.test_client.post('/tree/{}/save/{}'.format(generated_branch_name, fake_page_path), data={'layout': 'multi', 'hexsha': hexsha, 'en-title': 'Greetings', 'en-body': 'Hello world.\n', 'fr-title': '', 'fr-body': '', 'url-slug': 'hello'}, follow_redirects=True)
+            response = self.test_client.post('/tree/{}/save/{}'.format(generated_branch_name, fake_page_path), data={'layout': view_functions.ARTICLE_LAYOUT, 'hexsha': hexsha, 'en-title': 'Greetings', 'en-body': 'Hello world.\n', 'fr-title': '', 'fr-body': '', 'url-slug': 'hello'}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the task name should not be in the returned HTML
             self.assertFalse(EDIT_LISTDIR_TASK_DESCRIPTION_PATTERN.format(fake_task_description) in response.data)
@@ -1975,7 +1975,7 @@ class TestApp (TestCase):
             # an index page was created inside
             self.assertTrue(exists(idx_location))
             # the directory and index page pass the editable test
-            self.assertTrue(view_functions.is_editable_dir(dir_location))
+            self.assertTrue(view_functions.is_editable_dir(dir_location), view_functions.ARTICLE_LAYOUT)
 
     def test_can_rename_editable_directories(self):
         ''' Can rename an editable directory.
@@ -2010,7 +2010,7 @@ class TestApp (TestCase):
             new_page_slug = u'goodbye'
             new_page_path = u'{}/index.{}'.format(new_page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/save/{}'.format(working_branch_name, page_path),
-                                             data={'layout': 'multi', 'hexsha': hexsha,
+                                             data={'layout': view_functions.ARTICLE_LAYOUT, 'hexsha': hexsha,
                                                    'en-title': u'',
                                                    'en-body': u'',
                                                    'fr-title': u'', 'fr-body': u'',
@@ -2034,7 +2034,7 @@ class TestApp (TestCase):
             idx_location = u'{}/index.{}'.format(new_dir_location, view_functions.CONTENT_FILE_EXTENSION)
             self.assertTrue(exists(idx_location))
             # the directory and index page pass the editable test
-            self.assertTrue(view_functions.is_editable_dir(new_dir_location))
+            self.assertTrue(view_functions.is_editable_dir(new_dir_location, view_functions.ARTICLE_LAYOUT))
 
     def test_cannot_move_a_directory_inside_iteslf(self):
         ''' Can't rename an editable directory in a way which moves it inside itself
@@ -2069,7 +2069,7 @@ class TestApp (TestCase):
             new_page_slug = u'hello/is/better/than/goodbye'
             new_page_path = u'{}/index.{}'.format(new_page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/save/{}'.format(working_branch_name, page_path),
-                                             data={'layout': 'multi', 'hexsha': hexsha,
+                                             data={'layout': view_functions.ARTICLE_LAYOUT, 'hexsha': hexsha,
                                                    'en-title': u'',
                                                    'en-body': u'',
                                                    'fr-title': u'', 'fr-body': u'',

--- a/test/test.py
+++ b/test/test.py
@@ -1978,6 +1978,76 @@ class TestApp (TestCase):
             # the directory and index page pass the category test
             self.assertTrue(view_functions.is_category_dir(dir_location))
 
+    def test_create_many_categories_with_slash_separated_input(self):
+        ''' Entering a slash-separated string into the new article or category
+            field will create category folders where folders don't already exist
+        '''
+        fake_author_email = u'erica@example.com'
+        with HTTMock(self.mock_persona_verify):
+            self.test_client.post('/sign-in', data={'email': fake_author_email})
+
+        with HTTMock(self.auth_csv_example_allowed):
+            # start a new branch via the http interface
+            # invokes view_functions/get_repo which creates a clone
+            task_description = u'put the needle on the record'
+            task_beneficiary = u'all the people in the house'
+
+            working_branch = repo_functions.get_start_branch(self.clone1, 'master', task_description, task_beneficiary, fake_author_email)
+            self.assertTrue(working_branch.name in self.clone1.branches)
+            self.assertTrue(working_branch.name in self.origin.branches)
+            working_branch_name = working_branch.name
+            working_branch.checkout()
+
+            # create multiple new categories
+            page_slug = u'when/the/drum/beat'
+            response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
+                                             data={'action': 'add category', 'path': page_slug},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            # pull the changes
+            self.clone1.git.pull('origin', working_branch_name)
+
+            # category directories were created
+            dirs = page_slug.split('/')
+            for i in range(len(dirs)):
+                dir_location = join(self.clone1.working_dir, u'/'.join(dirs[:i + 1]))
+                # dir_location = join(self.clone1.working_dir, u'drum/beat/goes/like')
+                idx_location = u'{}/index.{}'.format(dir_location, view_functions.CONTENT_FILE_EXTENSION)
+                self.assertTrue(exists(dir_location) and isdir(dir_location))
+                # an index page was created inside
+                self.assertTrue(exists(idx_location))
+                # the directory and index page pass the category test
+                self.assertTrue(view_functions.is_category_dir(dir_location))
+
+            # now create a new page
+            page_slug = u'goes/like/this'
+            page_path = u'{}/index.{}'.format(page_slug, view_functions.CONTENT_FILE_EXTENSION)
+            response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
+                                             data={'action': 'add article', 'path': page_slug},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+            self.assertTrue(page_path in response.data)
+
+            # pull the changes
+            self.clone1.git.pull('origin', working_branch_name)
+
+            # category directories were created
+            dirs = page_slug.split('/')
+            for i in range(len(dirs)):
+                dir_location = join(self.clone1.working_dir, u'/'.join(dirs[:i + 1]))
+                # dir_location = join(self.clone1.working_dir, u'drum/beat/goes/like')
+                idx_location = u'{}/index.{}'.format(dir_location, view_functions.CONTENT_FILE_EXTENSION)
+                self.assertTrue(exists(dir_location) and isdir(dir_location))
+                # an index page was created inside
+                self.assertTrue(exists(idx_location))
+                if i < len(dirs) - 1:
+                    # the directory and index page pass the category test
+                    self.assertTrue(view_functions.is_category_dir(dir_location))
+                else:
+                    # the directory and index page pass the article test
+                    self.assertTrue(view_functions.is_article_dir(dir_location))
+
     def test_column_navigation_structure(self):
         ''' The column navigation structure matches the structure of the site.
         '''

--- a/test/test.py
+++ b/test/test.py
@@ -1570,7 +1570,7 @@ class TestApp (TestCase):
         with HTTMock(self.mock_google_analytics):
             # create a new file
             response = self.test_client.post('/tree/{}/edit/'.format(generated_branch_name),
-                                             data={'action': 'add', 'path': fake_page_slug},
+                                             data={'action': 'add article', 'path': fake_page_slug},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(fake_page_path in response.data)
@@ -1692,7 +1692,7 @@ class TestApp (TestCase):
             fake_task_beneficiary = u'Nobody'
             fake_author_email = u'erica@example.com'
             fake_branch_name = repo_functions.make_branch_name(fake_task_description, fake_task_beneficiary, fake_author_email)
-            response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add', 'path': fake_page_slug}, follow_redirects=True)
+            response = self.test_client.post('/tree/{}/edit/'.format(fake_branch_name), data={'action': 'add article', 'path': fake_page_slug}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)
             # the branch name should not be in the returned HTML
             self.assertFalse(EDIT_LISTDIR_BRANCH_NAME_PATTERN.format(fake_branch_name) in response.data)
@@ -1714,7 +1714,7 @@ class TestApp (TestCase):
             except AttributeError:
                 raise Exception('No match for generated branch name.')
 
-            response = self.test_client.post('/tree/{}/edit/'.format(generated_branch_name), data={'action': 'add', 'path': fake_page_slug}, follow_redirects=True)
+            response = self.test_client.post('/tree/{}/edit/'.format(generated_branch_name), data={'action': 'add article', 'path': fake_page_slug}, follow_redirects=True)
             self.assertEquals(response.status_code, 200)
 
             response = self.test_client.get('/tree/{}/edit/'.format(generated_branch_name), follow_redirects=True)
@@ -1963,7 +1963,7 @@ class TestApp (TestCase):
             page_slug = u'hello'
             page_path = u'{}/index.{}'.format(page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
-                                             data={'action': 'add', 'path': page_slug},
+                                             data={'action': 'add article', 'path': page_slug},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(page_path in response.data)
@@ -2003,7 +2003,7 @@ class TestApp (TestCase):
             page_slug = u'hello'
             page_path = u'{}/index.{}'.format(page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
-                                             data={'action': 'add', 'path': page_slug},
+                                             data={'action': 'add article', 'path': page_slug},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(page_path in response.data)
@@ -2062,7 +2062,7 @@ class TestApp (TestCase):
             page_slug = u'hello'
             page_path = u'{}/index.{}'.format(page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
-                                             data={'action': 'add', 'path': page_slug},
+                                             data={'action': 'add article', 'path': page_slug},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(page_path in response.data)
@@ -2119,7 +2119,7 @@ class TestApp (TestCase):
             page_slug = u'hello'
             page_path = u'{}/index.{}'.format(page_slug, view_functions.CONTENT_FILE_EXTENSION)
             response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
-                                             data={'action': 'add', 'path': page_slug},
+                                             data={'action': 'add article', 'path': page_slug},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(page_path in response.data)

--- a/test/test.py
+++ b/test/test.py
@@ -41,8 +41,7 @@ EDIT_LISTDIR_TASK_DESCRIPTION_PATTERN = '<h3>Current task: <strong>{}</strong>'
 EDIT_LISTDIR_TASK_DESCRIPTION_AND_BENEFICIARY_PATTERN = '<h3>Current task: <strong>{}</strong> for <strong>{}</strong></h3>'
 EDIT_LISTDIR_AUTHOR_EMAIL_PATTERN = '<li>Started by: <strong>{}</strong></li>'
 EDIT_LISTDIR_BRANCH_NAME_PATTERN = '<li class="active-task"><a href="./">{}</a></li>'
-EDIT_LISTDIR_FILE_NAME_PATTERN = '<a class="file" href="{file_name}">{file_name}</a>'
-EDIT_LISTDIR_FOLDER_NAME_PATTERN = '<a class="folder" href="{folder_name}">{folder_name}</a>'
+EDIT_LISTDIR_FILE_NAME_PATTERN = '<a class="{file_type}" href="{file_name}">{file_name}</a>'
 
 class TestJekyll (TestCase):
 
@@ -1579,7 +1578,7 @@ class TestApp (TestCase):
             # get the index page for the branch and verify that the new file is listed
             response = self.test_client.get('/tree/{}/edit/'.format(generated_branch_name), follow_redirects=True)
             self.assertEquals(response.status_code, 200)
-            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": fake_page_slug}) in response.data)
+            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": fake_page_slug, "file_type": view_functions.ARTICLE_LAYOUT}) in response.data)
 
             # get the edit page for the new file and extract the hexsha value
             response = self.test_client.get('/tree/{}/edit/{}'.format(generated_branch_name, fake_page_path))
@@ -1720,7 +1719,7 @@ class TestApp (TestCase):
 
             response = self.test_client.get('/tree/{}/edit/'.format(generated_branch_name), follow_redirects=True)
             self.assertEquals(response.status_code, 200)
-            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": fake_page_slug}) in response.data)
+            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": fake_page_slug, "file_type": view_functions.ARTICLE_LAYOUT}) in response.data)
 
             response = self.test_client.get('/tree/{}/edit/{}'.format(generated_branch_name, fake_page_path))
             self.assertEquals(response.status_code, 200)
@@ -1979,7 +1978,7 @@ class TestApp (TestCase):
             # an index page was created inside
             self.assertTrue(exists(idx_location))
             # the directory and index page pass the editable test
-            self.assertTrue(view_functions.is_editable_dir(dir_location), view_functions.ARTICLE_LAYOUT)
+            self.assertTrue(view_functions.is_article_dir(dir_location))
 
     def test_can_rename_editable_directories(self):
         ''' Can rename an editable directory.
@@ -2038,7 +2037,7 @@ class TestApp (TestCase):
             idx_location = u'{}/index.{}'.format(new_dir_location, view_functions.CONTENT_FILE_EXTENSION)
             self.assertTrue(exists(idx_location))
             # the directory and index page pass the editable test
-            self.assertTrue(view_functions.is_editable_dir(new_dir_location, view_functions.ARTICLE_LAYOUT))
+            self.assertTrue(view_functions.is_article_dir(new_dir_location))
 
     def test_cannot_move_a_directory_inside_iteslf(self):
         ''' Can't rename an editable directory in a way which moves it inside itself
@@ -2129,7 +2128,7 @@ class TestApp (TestCase):
             response = self.test_client.get('/tree/{}/edit/'.format(working_branch_name), follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             # verify that the new folder is represented as a file in the HTML
-            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": page_slug}) in response.data)
+            self.assertTrue(EDIT_LISTDIR_FILE_NAME_PATTERN.format(**{"file_name": page_slug, "file_type": view_functions.ARTICLE_LAYOUT}) in response.data)
 
 class TestPublishApp (TestCase):
 

--- a/test/test.py
+++ b/test/test.py
@@ -5,7 +5,7 @@ from unittest import main, TestCase
 
 from tempfile import mkdtemp
 from StringIO import StringIO
-from os.path import join, exists, dirname, isdir, abspath, isfile
+from os.path import join, exists, dirname, isdir, abspath, isfile, sep
 from urlparse import urlparse, urljoin
 from os import environ, remove
 from shutil import rmtree, copytree
@@ -1977,6 +1977,66 @@ class TestApp (TestCase):
             self.assertTrue(exists(idx_location))
             # the directory and index page pass the category test
             self.assertTrue(view_functions.is_category_dir(dir_location))
+
+    def test_column_navigation_structure(self):
+        ''' The column navigation structure matches the structure of the site.
+        '''
+        fake_author_email = u'erica@example.com'
+        with HTTMock(self.mock_persona_verify):
+            self.test_client.post('/sign-in', data={'email': fake_author_email})
+
+        with HTTMock(self.auth_csv_example_allowed):
+            # start a new branch via the http interface
+            # invokes view_functions/get_repo which creates a clone
+            task_description = u'force a clam shell open'
+            task_beneficiary = u'starfish'
+
+            working_branch = repo_functions.get_start_branch(self.clone1, 'master', task_description, task_beneficiary, fake_author_email)
+            self.assertTrue(working_branch.name in self.clone1.branches)
+            self.assertTrue(working_branch.name in self.origin.branches)
+            working_branch_name = working_branch.name
+            working_branch.checkout()
+
+            # create some nested categories
+            slug_hello = u'hello'
+            response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
+                                             data={'action': 'add category', 'path': slug_hello},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            slug_world = u'world'
+            response = self.test_client.post('/tree/{}/edit/{}'.format(working_branch_name, slug_hello),
+                                             data={'action': 'add category', 'path': slug_world},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            slug_how = u'how'
+            response = self.test_client.post('/tree/{}/edit/{}'.format(working_branch_name, sep.join([slug_hello, slug_world])),
+                                             data={'action': 'add category', 'path': slug_how},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            slug_are = u'are'
+            response = self.test_client.post('/tree/{}/edit/{}'.format(working_branch_name, sep.join([slug_hello, slug_world, slug_how])),
+                                             data={'action': 'add category', 'path': slug_are},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            # pull the changes
+            self.clone1.git.pull('origin', working_branch_name)
+
+            # get the columns
+            dir_columns = view_functions.directory_columns(self.clone1, working_branch_name, sep.join([slug_hello, slug_world, slug_how, slug_are]))
+
+            # test that the contents match our expectations
+            self.assertEquals(len(dir_columns), 3)
+            self.assertEquals(len(dir_columns[0]), 5)
+            expected = {'hello': u'category', 'index.md': u'file', 'other': u'folder', 'other.md': u'file', 'sub': u'folder'}
+            for item in dir_columns[0]:
+                self.assertTrue(item['name'] in expected)
+                self.assertTrue(expected[item['name']] == item['display_type'])
+            self.assertTrue(dir_columns[1][0]['name'] == slug_world)
+            self.assertTrue(dir_columns[2][0]['name'] == slug_how)
 
     def test_create_page_creates_directory_containing_index(self):
         ''' Creating a new page creates a directory with an editable index file inside.


### PR DESCRIPTION
Added support for navigating the site with columns

* *category* dirs can be created
* *category* dirs contain an index file with *category* layout in front matter
* a `dir_columns` list is available to templates; see articles-list.html for sample display
* improved support for *article* dirs
* improved support for dirs and files that are not *articles* or *categories*

Closes #216 
