### PR TITLE
Production alerts now include some request details.

### DIFF
--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -310,7 +310,7 @@ def log_application_errors(route_function):
         try:
             return route_function(*args, **kwargs)
         except Exception as e:
-            Logger.error(e, exc_info=True)
+            Logger.error(e, exc_info=True, extra={'request':request})
             raise
 
     return decorated_function

--- a/test/test_chimelog.py
+++ b/test/test_chimelog.py
@@ -1,5 +1,6 @@
 import sys
 from os.path import abspath, join, dirname
+from flask import Request
 
 repo_root = abspath(join(dirname(__file__), '..'))
 sys.path.insert(0, repo_root)
@@ -8,10 +9,39 @@ import unittest
 from unittest import TestCase
 from chime import SnsHandler
 from mock import Mock
-from logging import LogRecord, ERROR
+from logging import Logger, ERROR
 
 FAKE_ZONE = "us-east-1"
 FAKE_ARN = "arn:aws:sns:%s:123456789012:prod-alerts" % FAKE_ZONE
+
+
+def fake_request(scheme='http', host='example.org', path='/'):
+    return Request({
+        'wsgi.url_scheme': scheme,
+        'HTTP_HOST': host,
+        'SERVER_NAME': host,
+        'SERVER_PORT': '80',
+        'PATH_INFO': path,
+        'SCRIPT_NAME': '',
+        'QUERY_STRING': '',
+        'SERVER_PROTOCOL': 'HTTP/1.1',
+    })
+
+
+def fake_record(name, level, msg, exception=None, extra=None):
+    record = Logger("ignored").makeRecord( name, level, '/this/that', 123, msg, None, exc_info_for(exception), None, extra)
+    record.created = 1420099200  # 1/1/2015 Pacific
+    record.msecs = 0
+    return record
+
+
+def exc_info_for(exception):
+    if exception is None:
+        return None
+    try:
+        raise exception
+    except Exception:
+        return sys.exc_info()
 
 
 class TestableSnsHandler(SnsHandler):
@@ -35,39 +65,40 @@ class TestableSnsHandler(SnsHandler):
 
 
 class TestSnsHandler(TestCase):
-
     def setUp(self):
         super(TestSnsHandler, self).setUp()
         self.handler = TestableSnsHandler(FAKE_ARN)
 
     def test_setup(self):
-        self.assertEqual(self.handler.given_region_name, FAKE_ZONE)
+        self.assertEqual(FAKE_ZONE, self.handler.given_region_name)
 
     def test_basic_use(self):
-        self.handler.emit(self.fake_record('chime', ERROR, "Foo failed"))
-        self.assertEqual(self.handler.published_to_sns_topic(), FAKE_ARN)
-        self.assertRegexpMatches(self.handler.published_message(), '2015-01-01 00:00:00,000 - chime - ERROR - Foo failed')
-        self.assertEqual(self.handler.published_subject(), 'Production alert: ERROR: chime')
+        self.handler.emit(fake_record('chime', ERROR, "Foo failed"))
+        self.assertEqual(FAKE_ARN, self.handler.published_to_sns_topic())
+        self.assertEqual('Production alert: ERROR: chime', self.handler.published_subject())
+        self.assertIn('2015-01-01 00:00:00,000 - chime - ERROR - Foo failed', self.handler.published_message())
 
     def test_exception_use(self):
-        self.handler.emit(self.fake_record('chime', ERROR, "Foo failed", RuntimeError))
-        self.assertRegexpMatches(self.handler.published_message(), '2015-01-01 00:00:00,000 - chime - ERROR - Foo failed')
-        self.assertRegexpMatches(self.handler.published_message(), 'Traceback')
-        self.assertRegexpMatches(self.handler.published_message(), 'File.*line \d+')
+        self.handler.emit(fake_record('chime', ERROR, "Foo failed", RuntimeError))
+        message = self.handler.published_message()
+        self.assertIn('2015-01-01 00:00:00,000 - chime - ERROR - Foo failed', message)
+        self.assertIn('Traceback', message)
+        self.assertRegexpMatches(message, 'File.*line \d+')
 
-    def fake_record(self, name, level, msg, exception=None):
-        record = LogRecord(name, level, '/this/that', 123, msg, None, self.exc_info_for(exception))
-        record.created = 1420099200  # 1/1/2015 Pacific
-        record.msecs = 0
-        return record
+    def test_include_request_info(self):
+        request = fake_request('http', 'chime.chimecms.org', '/')
+        self.handler.emit(fake_record('chime', ERROR, "Foo failed", None, {"request": request}))
+        message = self.handler.published_message()
+        self.assertIn('GET', message)
+        self.assertIn('http://chime.chimecms.org/', message)
 
-    def exc_info_for(self, exception):
-        if exception is None:
-            return None
-        try:
-            raise exception
-        except Exception:
-            return sys.exc_info()
+    def test_include_request_info_on_exception(self):
+        request = fake_request('http', 'chime.chimecms.org', '/')
+        self.handler.emit(fake_record('chime', ERROR, "Foo failed", RuntimeError, {"request": request}))
+        message = self.handler.published_message()
+        self.assertIn('GET', message)
+        self.assertIn('http://chime.chimecms.org/', message)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds some basic request info to the production system error alerts. The actual information added is pretty small now; this change is mainly intended to create a place to easily add things to the reports as we realize what we really need to run down production errors.