### PR TITLE
redirect google analytics button on edit page to setup screen

### DIFF
--- a/chime/templates/article-edit.html
+++ b/chime/templates/article-edit.html
@@ -79,9 +79,7 @@
                 {% if app_authorized %}
                 <span class="toolbar__item">This week, <b>{{page_views}} people</b> spent an average of <b>{{average_time_page}} secs</b> on this page.</span>
                 {% else %}
-                <form method="POST" action="/authorize">
-                    <button id="authorize-button" class="toolbar__item button button--outline">Connect to Google Analytics</button>
-                </form>
+                <a href="/setup" class="toolbar__item button button--outline">Connect to Google Analytics</a>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
fixes #239. Instead of a form that posts to /authorize, makes the google analytics button just redirect to the /setup page so users can actually configure the google analytics.

cc @phae 