### PR TITLE
Fix failure on duplicate category or article creation

### DIFF
--- a/chime/edit_functions.py
+++ b/chime/edit_functions.py
@@ -2,8 +2,6 @@
 from os.path import exists, isdir, join, split, sep
 from os import rmdir, remove
 from slugify import slugify
-
-import repo_functions
 from .jekyll_functions import dump_jekyll_doc
 
 def update_page(clone, file_path, front, body):
@@ -29,14 +27,7 @@ def create_path_to_page(clone, dir_path, request_path, front, body, filename):
     ''' Build non-existing directories in request_path as category directories.
     '''
     # Build a full directory path.
-    head, dirs = split(request_path)[0], []
-
-    while head:
-        head, check_dir = split(head)
-        dirs.insert(0, check_dir)
-
-    if '..' in dirs:
-        raise Exception('Invalid path component.')
+    dirs = clone.dirs_for_path(request_path)
 
     # Build the category directory tree.
     file_paths = []

--- a/chime/edit_functions.py
+++ b/chime/edit_functions.py
@@ -54,12 +54,13 @@ def create_new_page(clone, dir_path, request_path, front, body):
     front_copy = dict(front)
     if not front_copy['title']:
         front_copy['title'] = request_path.split('/')[-2]
-    file_path, full_path = repo_functions.make_working_file(clone, dir_path, slug_path)
+    file_path = clone.repo_path(dir_path, slug_path)
+    clone.create_directories_if_necessary(file_path)
 
-    if exists(full_path):
+    if clone.exists(file_path):
         raise Exception(u'create_new_page: path already exists!')
 
-    with open(full_path, 'w') as file:
+    with open(clone.full_path(file_path), 'w') as file:
         dump_jekyll_doc(front_copy, body, file)
 
     return file_path
@@ -67,10 +68,11 @@ def create_new_page(clone, dir_path, request_path, front, body):
 def upload_new_file(clone, dir_path, upload):
     ''' Upload a new file in the working directory, return its path.
     '''
-    file_path, full_path = repo_functions.make_working_file(clone, dir_path, upload.filename)
 
-    if not exists(full_path):
-        with open(full_path, 'w') as file:
+    file_path = clone.repo_path(dir_path, upload.filename)
+
+    if not clone.exists(file_path):
+        with open(clone.full_path(file_path), 'w') as file:
             upload.save(file)
 
     return file_path

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -45,7 +45,8 @@ class ChimeRepo(Repo):
         return join(*args)
 
     def canonicalize_path(self, *args):
-
+        ''' Return a slugified version of the passed path
+        '''
         result = join((args[0] or '').rstrip('/'), *args[1:])
         split_path = split(result) # also probably belongs up in request handling code
         result = join(make_slug_path(split_path[0]), split_path[1])
@@ -56,14 +57,11 @@ class ChimeRepo(Repo):
         return exists(self.full_path(path_in_repo))
 
     def create_directories_if_necessary(self, path):
-        """
-        Creates any necessary directories for a path, ignoring any
-        file component. If you pass "foo/bar.txt" it'll create directory foo.
-        If you pass "foo/bar/" it will create foo and foo/bar.
-        :param path:
-        :return:
-        """
-        dirs = self._dirs_for_path(path)
+        ''' Creates any necessary directories for a path, ignoring any file component.
+            If you pass "foo/bar.txt" or "foo/bar" it'll create directory "foo".
+            If you pass "foo/bar/" it will create directories "foo" and "foo/bar".
+        '''
+        dirs = self.dirs_for_path(path)
 
         # Create directory tree.
         #
@@ -73,7 +71,7 @@ class ChimeRepo(Repo):
             if not isdir(build_path):
                 mkdir(build_path)
 
-    def _dirs_for_path(self, path):
+    def dirs_for_path(self, path):
         head, dirs = split(path)[0], []
         while head:
             head, check_dir = split(head)

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -73,7 +73,6 @@ class ChimeRepo(Repo):
             if not isdir(build_path):
                 mkdir(build_path)
 
-
     def _dirs_for_path(self, path):
         head, dirs = split(path)[0], []
         while head:
@@ -83,8 +82,6 @@ class ChimeRepo(Repo):
             raise Exception('Invalid path component.')
 
         return dirs
-
-
 
 def _origin(branch_name):
     ''' Format the branch name into a origin path and return it.

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -597,18 +597,9 @@ def directory_columns(clone, branch_name, repo_path=None, showallfiles=False):
                 }
             ]
     '''
-    repo_path = repo_path or u''
-
     # Build a full directory path.
-    head, dirs = split(repo_path)[0], []
-
-    while head:
-        head, dir = split(head)
-        dirs.insert(0, dir)
-
-    if '..' in dirs:
-        raise Exception('Invalid path component.')
-
+    repo_path = repo_path or u''
+    dirs = clone.dirs_for_path(repo_path)
     # make sure we get the root dir
     dirs.insert(0, u'')
 

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -19,7 +19,7 @@ from dateutil.relativedelta import relativedelta
 from flask import request, session, current_app, redirect, flash
 from requests import get
 
-from .repo_functions import get_existing_branch, ignore_task_metadata_on_merge
+from .repo_functions import get_existing_branch, ignore_task_metadata_on_merge, ChimeRepo
 from .jekyll_functions import load_jekyll_doc
 from .href import needs_redirect, get_redirect
 
@@ -92,13 +92,13 @@ def get_repo(flask_app):
         the cloned directory, to reduce history conflicts when tweaking
         the repository during development.
     '''
-    source_repo = Repo(flask_app.config['REPO_PATH'])
+    source_repo = ChimeRepo(flask_app.config['REPO_PATH'])
     first_commit = list(source_repo.iter_commits())[-1].hexsha
     dir_name = 'repo-{}-{}'.format(first_commit[:8], session.get('email', 'nobody'))
     user_dir = realpath(join(flask_app.config['WORK_PATH'], quote(dir_name)))
 
     if isdir(user_dir):
-        user_repo = Repo(user_dir)
+        user_repo = ChimeRepo(user_dir)
         user_repo.git.reset(hard=True)
         user_repo.remotes.origin.fetch()
     else:

--- a/chime/views.py
+++ b/chime/views.py
@@ -519,7 +519,7 @@ def add_article_or_category(repo, path, create_what, request_path):
     elif create_what == 'category':
         file_path = repo.canonicalize_path(path, name)
         if repo.exists(file_path):
-            message = 'Category "{}" already exists'.format(file_path)
+            message = 'Category "{}" already exists'.format(request_path)
             return message, file_path, strip_index_file(file_path), False
         else:
             file_path = edit_functions.create_new_page(repo, path, name, cat_front, body)
@@ -554,7 +554,13 @@ def branch_edit_file(branch, path=None):
 
     elif action == 'create' and (create_what == 'article' or create_what == 'category') and create_path is not None:
         message, file_path, redirect_path, do_save = add_article_or_category(repo, create_path, create_what, request.form['path'])
-        commit = repo.commit()
+        if do_save:
+            commit = repo.commit()
+        else:
+            import sys
+
+            sys.stderr.write("flashing!\n")
+            flash(message, u'notice')
 
 
 

--- a/chime/views.py
+++ b/chime/views.py
@@ -79,7 +79,6 @@ def index():
         task_description = task_metadata['task_description'] if 'task_description' in task_metadata else name
         task_beneficiary = task_metadata['task_beneficiary'] if 'task_beneficiary' in task_metadata else u''
 
-
         list_items.append(dict(name=name, path=path, behind=behind, ahead=ahead,
                                needs_peer_review=needs_peer_review,
                                is_peer_approved=is_peer_approved,
@@ -89,11 +88,8 @@ def index():
                                author_email=author_email, task_description=task_description,
                                task_beneficiary=task_beneficiary, is_eligible_peer=is_eligible_peer, last_editor=last_editor))
 
-
     kwargs = common_template_args(current_app.config, session)
     kwargs.update(items=list_items)
-
-
 
     return render_template('activities-list.html', **kwargs)
 
@@ -561,8 +557,6 @@ def branch_edit_file(branch, path=None):
             commit = repo.commit()
         else:
             flash(message, u'notice')
-
-
 
     elif action == 'delete' and 'path' in request.form:
         request_path = request.form['path']

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -372,7 +372,7 @@ class TestRepo (TestCase):
         self.assertEqual(u'categories/my-new-category/', first_result[2])
         self.assertEqual(True, first_result[3])
         second_result = views.add_article_or_category(self.clone1, 'categories', 'category', 'my new category')
-        self.assertEqual('Category "categories/my-new-category/index.markdown" already exists', second_result[0])
+        self.assertEqual('Category "my new category" already exists', second_result[0])
         self.assertEqual(u'categories/my-new-category/index.markdown', second_result[1])
         self.assertEqual(u'categories/my-new-category/', second_result[2])
         self.assertEqual(False, second_result[3])
@@ -2040,6 +2040,7 @@ class TestApp (TestCase):
                                              data=request_data,
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
+            self.assertTrue(u'Category &#34;hello&#34; already exists' in response.data)
 
 
             # pull the changes

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -377,6 +377,19 @@ class TestRepo (TestCase):
         self.assertEqual(u'categories/my-new-category/', second_result[2])
         self.assertEqual(False, second_result[3])
 
+    def test_try_to_create_existing_article(self):
+
+        first_result = views.add_article_or_category(self.clone1, 'categories/example', 'article', 'new article')
+        self.assertEqual('Created new article "categories/example/new-article/index.markdown"', first_result[0])
+        self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
+        self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
+        self.assertEqual(True, first_result[3])
+        second_result = views.add_article_or_category(self.clone1, 'categories/example', 'article', 'new article')
+        self.assertEqual('Article "new article" already exists', second_result[0])
+        self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
+        self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
+        self.assertEqual(False, second_result[3])
+
     def test_delete_directory(self):
         ''' Make a new file and directory and delete them.
         '''

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -78,7 +78,7 @@ class TestViewFunctions (TestCase):
         temp_repo_dir = mkdtemp(prefix='chime-root')
         temp_repo_path = temp_repo_dir + '/test-app.git'
         copytree(repo_path, temp_repo_path)
-        self.origin = Repo(temp_repo_path)
+        self.origin = ChimeRepo(temp_repo_path)
         repo_functions.ignore_task_metadata_on_merge(self.origin)
         self.clone = self.origin.clone(mkdtemp(prefix='chime-'))
         repo_functions.ignore_task_metadata_on_merge(self.clone)
@@ -366,12 +366,12 @@ class TestRepo (TestCase):
 
     def test_try_to_create_existing_category(self):
 
-        first_result = views.add_article_or_category(self.clone1, 'categories', 'category', 'my new category')
+        first_result = views.add_article_or_category(self.clone1, 'categories', 'my new category', view_functions.CATEGORY_LAYOUT)
         self.assertEqual('Created new category "categories/my-new-category/index.markdown"', first_result[0])
         self.assertEqual(u'categories/my-new-category/index.markdown', first_result[1])
         self.assertEqual(u'categories/my-new-category/', first_result[2])
         self.assertEqual(True, first_result[3])
-        second_result = views.add_article_or_category(self.clone1, 'categories', 'category', 'my new category')
+        second_result = views.add_article_or_category(self.clone1, 'categories', 'my new category', view_functions.CATEGORY_LAYOUT)
         self.assertEqual('Category "my new category" already exists', second_result[0])
         self.assertEqual(u'categories/my-new-category/index.markdown', second_result[1])
         self.assertEqual(u'categories/my-new-category/', second_result[2])
@@ -379,12 +379,12 @@ class TestRepo (TestCase):
 
     def test_try_to_create_existing_article(self):
 
-        first_result = views.add_article_or_category(self.clone1, 'categories/example', 'article', 'new article')
+        first_result = views.add_article_or_category(self.clone1, 'categories/example', 'new article', view_functions.ARTICLE_LAYOUT)
         self.assertEqual('Created new article "categories/example/new-article/index.markdown"', first_result[0])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
         self.assertEqual(True, first_result[3])
-        second_result = views.add_article_or_category(self.clone1, 'categories/example', 'article', 'new article')
+        second_result = views.add_article_or_category(self.clone1, 'categories/example', 'new article', view_functions.ARTICLE_LAYOUT)
         self.assertEqual('Article "new article" already exists', second_result[0])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
@@ -1423,7 +1423,7 @@ class TestApp (TestCase):
         temp_repo_dir = mkdtemp(prefix='chime-root')
         temp_repo_path = temp_repo_dir + '/test-app.git'
         copytree(repo_path, temp_repo_path)
-        self.origin = Repo(temp_repo_path)
+        self.origin = ChimeRepo(temp_repo_path)
         repo_functions.ignore_task_metadata_on_merge(self.origin)
         self.clone1 = self.origin.clone(mkdtemp(prefix='chime-'))
         repo_functions.ignore_task_metadata_on_merge(self.clone1)
@@ -2054,7 +2054,6 @@ class TestApp (TestCase):
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
             self.assertTrue(u'Category &#34;hello&#34; already exists' in response.data)
-
 
             # pull the changes
             self.clone1.git.pull('origin', working_branch.name)


### PR DESCRIPTION
This hopefully fixes our blowy-uppy behavior when people try to create things that already exist.

It also creates a ChimeRepo object and moves some file-related code into it, hopefully improving clarity.