### PR TITLE
Add order and description to front matter

### DIFF
--- a/chime/templates/article-edit.html
+++ b/chime/templates/article-edit.html
@@ -14,17 +14,23 @@
 
     <input name="layout" value="{{front['layout']}}" type="hidden" />
     <input name="hexsha" value="{{hexsha}}" type="hidden" />
-    <input name="url-slug" type="hidden" value="{{url_slug}}" />  
+    <input name="url-slug" type="hidden" value="{{url_slug}}" />
+    <input name="order" type="hidden" value="{{front['order']}}" />
 {% for iso in languages %}
     {% if iso == 'en' %}
         {% set form_title = front['title'] %}
+        {% set form_description = front['description'] %}
         {% set form_body = body %}
         {% set display_class = '' %}
     {% else %}
         {% set form_title = front['title-'+iso] %}
+        {% set form_description = front['description-'+iso] %}
         {% set form_body = front['body-'+iso] %}
         {% set display_class = 'is-hidden' %}
     {% endif %}
+
+    <input name="{{iso}}-description" type="hidden" value="{{form_description}}" />
+
     <div class="edit-article__header row">
         <div class="row__left">
             <div class="selection-box">
@@ -52,9 +58,6 @@
             <input type="submit" class="button button--green toolbar__item" value="Save"/>
         </div>
     </div>    
-    
-    
-
     <div class="edit-article__main row col__flex">
         <div class="edit-article__editor row__left col">
             <textarea id="{{iso}}-body markItUp" class="col__flex" name="{{iso}}-body" type="text" data-provide="markdown" data-iconlibrary="fa" data-hidden-buttons="cmdPreview">{{form_body}}</textarea>
@@ -82,8 +85,8 @@
                 <a href="/setup" class="toolbar__item button button--outline">Connect to Google Analytics</a>
                 {% endif %}
             </div>
-        </div>
-        {% endfor %}
+    </div>
+{% endfor %}
 </form>
 <script type="text/javascript">
     {% for iso in languages %}

--- a/chime/views.py
+++ b/chime/views.py
@@ -678,9 +678,9 @@ def branch_save(branch, path):
         flash(u'There is no {} branch!'.format(branch), u'warning')
         return redirect('/')
 
-    c = existing_branch.commit
+    commit = existing_branch.commit
 
-    if c.hexsha != request.form.get('hexsha'):
+    if commit.hexsha != request.form.get('hexsha'):
         raise Exception('Out of date SHA: %s' % request.form.get('hexsha'))
 
     #
@@ -688,9 +688,15 @@ def branch_save(branch, path):
     #
     existing_branch.checkout()
 
+    # make sure order is an integer; otherwise default to 0
+    try:
+        order = int(dos2unix(request.form.get('order', '0')))
+    except ValueError:
+        order = 0
+
     front = {
         'layout': dos2unix(request.form.get('layout')),
-        'order': int(dos2unix(request.form.get('order', '0'))),
+        'order': order,
         'title': dos2unix(request.form.get('en-title', '')),
         'description': dos2unix(request.form.get('en-description', ''))
     }
@@ -701,7 +707,7 @@ def branch_save(branch, path):
             front['description-' + iso] = dos2unix(request.form.get(iso + '-description', ''))
             front['body-' + iso] = dos2unix(request.form.get(iso + '-body', ''))
 
-    body = dos2unix(request.form.get('en-body'))
+    body = dos2unix(request.form.get('en-body', ''))
     edit_functions.update_page(repo, path, front, body)
 
     #
@@ -709,7 +715,7 @@ def branch_save(branch, path):
     #
     try:
         message = 'Saved file "{}"'.format(path)
-        c2 = repo_functions.save_working_file(repo, path, message, c.hexsha, master_name)
+        c2 = repo_functions.save_working_file(repo, path, message, commit.hexsha, master_name)
         # they may've renamed the page by editing the URL slug
         original_slug = path
         if search(r'\/index.{}$'.format(CONTENT_FILE_EXTENSION), path):
@@ -717,28 +723,29 @@ def branch_save(branch, path):
 
         # do some simple input cleaning
         new_slug = request.form.get('url-slug')
-        new_slug = sub(r'\/+', '/', new_slug)
+        if new_slug:
+            new_slug = sub(r'\/+', '/', new_slug)
 
-        if new_slug != original_slug:
-            try:
-                repo_functions.move_existing_file(repo, original_slug, new_slug, c2.hexsha, master_name)
-            except Exception as e:
-                error_message = e.args[0]
-                error_type = e.args[1] if len(e.args) > 1 else None
-                # let unexpected errors raise normally
-                if error_type:
-                    flash(error_message, error_type)
-                    return redirect('/tree/{}/edit/{}'.format(safe_branch, path), code=303)
-                else:
-                    raise
+            if new_slug != original_slug:
+                try:
+                    repo_functions.move_existing_file(repo, original_slug, new_slug, c2.hexsha, master_name)
+                except Exception as e:
+                    error_message = e.args[0]
+                    error_type = e.args[1] if len(e.args) > 1 else None
+                    # let unexpected errors raise normally
+                    if error_type:
+                        flash(error_message, error_type)
+                        return redirect('/tree/{}/edit/{}'.format(safe_branch, path), code=303)
+                    else:
+                        raise
 
-            path = new_slug
-            # append the index file if it's an editable directory
-            if is_article_dir(join(repo.working_dir, new_slug)):
-                path = join(new_slug, u'index.{}'.format(CONTENT_FILE_EXTENSION))
+                path = new_slug
+                # append the index file if it's an editable directory
+                if is_article_dir(join(repo.working_dir, new_slug)):
+                    path = join(new_slug, u'index.{}'.format(CONTENT_FILE_EXTENSION))
 
     except repo_functions.MergeConflict as conflict:
-        repo.git.reset(c.hexsha, hard=True)
+        repo.git.reset(commit.hexsha, hard=True)
 
         Logger.debug('1 {}'.format(conflict.remote_commit))
         Logger.debug('  {}'.format(repr(conflict.remote_commit.tree[path].data_stream.read())))

--- a/chime/views.py
+++ b/chime/views.py
@@ -669,11 +669,17 @@ def branch_save(branch, path):
     #
     existing_branch.checkout()
 
-    front = {'layout': dos2unix(request.form.get('layout')), 'title': dos2unix(request.form.get('en-title'))}
+    front = {
+        'layout': dos2unix(request.form.get('layout')),
+        'order': int(dos2unix(request.form.get('order', '0'))),
+        'title': dos2unix(request.form.get('en-title', '')),
+        'description': dos2unix(request.form.get('en-description', ''))
+    }
 
     for iso in load_languages(repo.working_dir):
         if iso != 'en':
             front['title-' + iso] = dos2unix(request.form.get(iso + '-title', ''))
+            front['description-' + iso] = dos2unix(request.form.get(iso + '-description', ''))
             front['body-' + iso] = dos2unix(request.form.get(iso + '-body', ''))
 
     body = dos2unix(request.form.get('en-body'))

--- a/chime/views.py
+++ b/chime/views.py
@@ -495,8 +495,8 @@ def branch_edit(branch, path=None):
 def add_article_or_category(repo, path, create_what, request_path):
     ''' Add an article or category
     '''
-    article_front = dict(title=u'', layout=ARTICLE_LAYOUT)
-    cat_front = dict(title=u'', layout=CATEGORY_LAYOUT)
+    article_front = dict(title=u'', description=u'', order=0, layout=ARTICLE_LAYOUT)
+    cat_front = dict(title=u'', description=u'', order=0, layout=CATEGORY_LAYOUT)
     body = u''
 
     # create and commit intermediate categories

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -2189,6 +2189,9 @@ class TestApp (TestCase):
                                                    'en-title': new_cat_title, 'en-description': cat_description, 'order': cat_order},
                                              follow_redirects=True)
             self.assertEquals(response.status_code, 200)
+            # check the returned HTML for the description and order values (format will change as pages are designed)
+            self.assertTrue(u'<input name="en-description" type="hidden" value="{}" />'.format(cat_description) in response.data)
+            self.assertTrue(u'<input name="order" type="hidden" value="{}" />'.format(cat_order) in response.data)
 
             # pull the changes
             self.clone1.git.pull('origin', working_branch_name)

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -2111,7 +2111,6 @@ class TestApp (TestCase):
             # the title saved in the index front matter is displayed on the article list page
             response = self.test_client.get('/tree/{}/edit/'.format(working_branch_name), follow_redirects=True)
             self.assertTrue(PATTERN_FILE_COMMENT.format(**{"file_name": cat_title_slugified, "file_title": cat_title, "file_type": view_functions.CATEGORY_LAYOUT}) in response.data)
-            self.assertTrue(cat_title in response.data)
 
             # create a new article
             art_title = u'快速狐狸'
@@ -2140,6 +2139,78 @@ class TestApp (TestCase):
             self.assertTrue(PATTERN_TEMPLATE_COMMENT.format(u'articles-list') in response.data.decode('utf-8'))
             self.assertTrue(PATTERN_BRANCH_COMMENT.format(working_branch) in response.data.decode('utf-8'))
             self.assertTrue(PATTERN_FILE_COMMENT.format(**{"file_name": art_title_slugified, "file_title": art_title, "file_type": view_functions.ARTICLE_LAYOUT}) in response.data.decode('utf-8'))
+
+    def test_set_and_retrieve_order_and_description(self):
+        ''' Order and description can be set to and retrieved from an article's or category's front matter.
+        '''
+        fake_author_email = u'erica@example.com'
+        with HTTMock(self.mock_persona_verify):
+            self.test_client.post('/sign-in', data={'email': fake_author_email})
+
+        with HTTMock(self.auth_csv_example_allowed):
+            # start a new branch via the http interface
+            # invokes view_functions/get_repo which creates a clone
+            task_description = u'regurgitate partially digested worms and grubs'
+            task_beneficiary = u'baby birds'
+
+            working_branch = repo_functions.get_start_branch(self.clone1, 'master', task_description, task_beneficiary, fake_author_email)
+            self.assertTrue(working_branch.name in self.clone1.branches)
+            self.assertTrue(working_branch.name in self.origin.branches)
+            working_branch_name = working_branch.name
+            working_branch.checkout()
+
+            # create a categories directory
+            categories_slug = u'categories'
+            response = self.test_client.post('/tree/{}/edit/'.format(working_branch_name),
+                                             data={'action': 'create', 'create_what': view_functions.CATEGORY_LAYOUT, 'path': categories_slug},
+                                             follow_redirects=True)
+
+            # and put a new category inside it
+            cat_title = u'Small Intestine'
+            cat_title_slugified = u'small-intestine'
+            response = self.test_client.post('/tree/{}/edit/{}'.format(working_branch_name, categories_slug),
+                                             data={'action': 'create', 'create_what': view_functions.CATEGORY_LAYOUT, 'path': cat_title},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            # pull the changes
+            self.clone1.git.pull('origin', working_branch_name)
+
+            # get the hexsha
+            hexsha = self.clone1.commit().hexsha
+
+            # now save some values into the category's index page's front matter
+            new_cat_title = u'The Small Intestine'
+            cat_description = u'The part of the GI tract following the stomach and followed by the large intestine where much of the digestion and absorption of food takes place.'
+            cat_order = 3
+            cat_path = join(categories_slug, cat_title_slugified, u'index.{}'.format(view_functions.CONTENT_FILE_EXTENSION))
+            response = self.test_client.post('/tree/{}/save/{}'.format(working_branch_name, cat_path),
+                                             data={'layout': view_functions.CATEGORY_LAYOUT, 'hexsha': hexsha,
+                                                   'en-title': new_cat_title, 'en-description': cat_description, 'order': cat_order},
+                                             follow_redirects=True)
+            self.assertEquals(response.status_code, 200)
+
+            # pull the changes
+            self.clone1.git.pull('origin', working_branch_name)
+
+            # a directory was created
+            dir_location = join(self.clone1.working_dir, categories_slug, cat_title_slugified)
+            idx_location = u'{}/index.{}'.format(dir_location, view_functions.CONTENT_FILE_EXTENSION)
+            self.assertTrue(exists(dir_location) and isdir(dir_location))
+            # an index page was created inside
+            self.assertTrue(exists(idx_location))
+            # the directory and index page pass the category test
+            self.assertTrue(view_functions.is_category_dir(dir_location))
+            # the title saved in the index front matter is the same text that was used to create the category
+            self.assertEqual(view_functions.get_value_from_front_matter('title', idx_location), new_cat_title)
+
+            # check order and description
+            self.assertEqual(view_functions.get_value_from_front_matter('order', idx_location), cat_order)
+            self.assertEqual(view_functions.get_value_from_front_matter('description', idx_location), cat_description)
+
+            # the title saved in the index front matter is displayed on the article list page
+            response = self.test_client.get('/tree/{}/edit/{}'.format(working_branch_name, categories_slug), follow_redirects=True)
+            self.assertTrue(PATTERN_FILE_COMMENT.format(**{"file_name": cat_title_slugified, "file_title": new_cat_title, "file_type": view_functions.CATEGORY_LAYOUT}) in response.data)
 
     def test_create_many_categories_with_slash_separated_input(self):
         ''' Entering a slash-separated string into the new article or category


### PR DESCRIPTION
values for order and description are:
* read from article or category front matter
* sent to the article-edit template
* rendered on the article-edit page in hidden form fields
* expected on article or category save and stored in front matter

part of #244 and #183 but doesn't close either.