### PR TITLE
Delete unpulled activities #293

### DIFF
--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -549,14 +549,20 @@ def synched_checkout_required(route_function):
             repo.git.fetch('origin', with_exceptions=True)
 
         checkout = get_repo(current_app)
-        branch_name = branch_var2name(kwargs['branch'])
+
+        # get the branch name from request.form if it's not in kwargs
+        branch_name_raw = kwargs['branch'] if 'branch' in kwargs else None
+        if not branch_name_raw:
+            branch_name_raw = request.form.get('branch', None)
+
+        branch_name = branch_var2name(branch_name_raw)
         master_name = current_app.config['default_branch']
         branch = get_existing_branch(checkout, master_name, branch_name)
 
         if not branch:
             # redirect and flash an error
-            Logger.debug('  branch {} does not exist, redirecting'.format(kwargs['branch']))
-            flash(u'There is no {} branch!'.format(kwargs['branch']), u'warning')
+            Logger.debug('  branch {} does not exist, redirecting'.format(branch_name_raw))
+            flash(u'There is no {} branch!'.format(branch_name_raw), u'warning')
             return redirect('/')
 
         branch.checkout()

--- a/chime/views.py
+++ b/chime/views.py
@@ -254,7 +254,7 @@ def start_branch():
 @app.route('/update', methods=['POST'])
 @log_application_errors
 @login_required
-@synch_required
+@synched_checkout_required
 def update_activity():
     ''' Update the activity review state or merge, abandon, or clobber the posted branch
     '''

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -1861,6 +1861,11 @@ class TestApp (TestCase):
                     new_clone = view_functions.get_repo(self.app)
                     self.assertFalse(check_branch.name in new_clone.branches)
 
+            # load the activity list and verify that the branch is visible there
+            response = self.test_client.get('/', follow_redirects=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(check_branch.name in response.data)
+
             # Delete the activity
             response = self.test_client.post('/update', data={'abandon': 'Delete', 'branch': '{}'.format(check_branch.name)}, follow_redirects=True)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Fixes a bug where deleting activities that hadn't been viewed or edited by you errored

* wrote a test to expose the bug
* required a synched checkout on /update
* updated synched_checkout_required() to check request.form for branch name

Closes #293 
