### PR TITLE
Added worker process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: gunicorn -b 0.0.0.0:5000 -w 8 chime.wsgi:app
+worker: PYTHONUNBUFFERED=true python -m chime.worker
 gapi_access_token: PYTHONUNBUFFERED=true python -m chime.google_access_token_update --hourly

--- a/chime/google_access_token_update.py
+++ b/chime/google_access_token_update.py
@@ -1,36 +1,24 @@
+''' Do nothing.
+
+The activities previously defined here have moved to chime.worker.
+'''
 from __future__ import absolute_import
 from logging import getLogger
 Logger = getLogger('chime.google_access_token_update')
 
-from .google_api_functions import request_new_google_access_token, read_ga_config
 import argparse
-from os import environ
-import traceback
-import sys
 from time import sleep
 
-parser = argparse.ArgumentParser(description='Update google access token')
-
-parser.add_argument('--hourly', action='store_true',
-                    help='Ask for new access token from Google API hourly.')
+parser = argparse.ArgumentParser(description='Do nothing.')
+parser.add_argument('--hourly', action='store_true', help='Do nothing hourly.')
 
 if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    ''' Periodically get a new access_token and store it. This keeps the user from
-      having to keep authing with google
-    '''
     while True:
-        try:
-            ga_config = read_ga_config(environ['RUNNING_STATE_DIR'])
-            request_new_google_access_token(ga_config.get('refresh_token'), environ['RUNNING_STATE_DIR'], environ['GA_CLIENT_ID'], environ['GA_CLIENT_SECRET'])
-        except:
-            traceback.print_exc(file=sys.stderr)
+        if not args.hourly:
+            break
 
-        finally:
-            if not args.hourly:
-                break
-
-            Logger.debug('Sleeping.')
-            sleep(3600)
+        Logger.debug('Sleeping.')
+        sleep(3600)

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+from logging import getLogger
+Logger = getLogger('chime.worker')
+
+import argparse
+import time
+
+parser = argparse.ArgumentParser(description='Do the things that need doing.')
+
+if __name__ == '__main__':
+
+    args = parser.parse_args()
+
+    while True:
+        Logger.debug('Sleeping.')
+        time.sleep(3600)

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -5,17 +5,19 @@ Logger = getLogger('chime.worker')
 import os
 import argparse
 import time
+import sys
+import traceback
 
 from .google_api_functions import (
     is_overdue_ga_config, read_ga_config, request_new_google_access_token
-    )
+)
 
 parser = argparse.ArgumentParser(description='Do the things that need doing.')
 
 if __name__ == '__main__':
 
     args = parser.parse_args()
-    
+
     running_state_dir, ga_client_id, ga_client_secret = \
         os.environ['RUNNING_STATE_DIR'], os.environ['GA_CLIENT_ID'], \
         os.environ['GA_CLIENT_SECRET']
@@ -31,7 +33,7 @@ if __name__ == '__main__':
                 token_args = (
                     read_ga_config(running_state_dir).get('refresh_token'),
                     running_state_dir, ga_client_id, ga_client_secret
-                    )
+                )
                 request_new_google_access_token(*token_args)
         except:
             traceback.print_exc(file=sys.stderr)

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -2,15 +2,39 @@ from __future__ import absolute_import
 from logging import getLogger
 Logger = getLogger('chime.worker')
 
+import os
 import argparse
 import time
+
+from .google_api_functions import (
+    is_overdue_ga_config, read_ga_config, request_new_google_access_token
+    )
 
 parser = argparse.ArgumentParser(description='Do the things that need doing.')
 
 if __name__ == '__main__':
 
     args = parser.parse_args()
+    
+    running_state_dir, ga_client_id, ga_client_secret = \
+        os.environ['RUNNING_STATE_DIR'], os.environ['GA_CLIENT_ID'], \
+        os.environ['GA_CLIENT_SECRET']
 
     while True:
+        #
+        # Periodically get a new access_token and store it.
+        # This keeps the user from having to keep authing with Google.
+        #
+        try:
+            if is_overdue_ga_config(running_state_dir):
+                Logger.info('Updating GA config in {}.'.format(running_state_dir))
+                token_args = (
+                    read_ga_config(running_state_dir).get('refresh_token'),
+                    running_state_dir, ga_client_id, ga_client_secret
+                    )
+                request_new_google_access_token(*token_args)
+        except:
+            traceback.print_exc(file=sys.stderr)
+
         Logger.debug('Sleeping.')
-        time.sleep(3600)
+        time.sleep(5)


### PR DESCRIPTION
As part of #287, added a new `worker` process and moved GA token exchange there. Keeping the old `gapi_access_token ` process around as a no-op because Honcho doesn’t understand how to remove existing entries, only add and replace.