### PR TITLE
Add git backup sync daemon

### DIFF
--- a/chime/__init__.py
+++ b/chime/__init__.py
@@ -14,9 +14,6 @@ from .httpd import run_apache_forever
 
 chime = Blueprint('chime', __name__, template_folder='templates')
 
-# Name of file in running state dir that signals a need to push upstream.
-NEEDS_PUSH_FILE = 'needs-push'
-
 class AppShim:
 
     def __init__(self, app):

--- a/chime/__init__.py
+++ b/chime/__init__.py
@@ -14,6 +14,9 @@ from .httpd import run_apache_forever
 
 chime = Blueprint('chime', __name__, template_folder='templates')
 
+# Name of file in running state dir that signals a need to push upstream.
+NEEDS_PUSH_FILE = 'needs-push'
+
 class AppShim:
 
     def __init__(self, app):

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -730,6 +730,15 @@ def _remote_exists(repo, remote):
     else:
         return True
 
+def mark_upstream_push_needed(running_state_dir):
+    ''' Add needs-push file for use by push_upstream_if_needed().
+    '''
+    needs_push_file = join(running_state_dir, NEEDS_PUSH_FILE)
+    
+    with google_api_functions.WriteLocked(needs_push_file) as file:
+        file.truncate()
+        file.write('Yes')
+
 def push_upstream_if_needed(repo, running_state_dir):
     ''' If needs-push file is found and origin exists, push it.
     '''

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -746,7 +746,8 @@ def push_upstream_if_needed(repo, running_state_dir):
 
     if exists(needs_push_file):
         with google_api_functions.WriteLocked(needs_push_file) as file:
-            if _remote_exists(repo, 'origin'):
-                logging.info('  pushing origin {}'.format(repo))
-                repo.git.push('origin', all=True, with_exceptions=True)
             remove(file.name)
+
+        if _remote_exists(repo, 'origin'):
+            logging.info('  pushing origin {}'.format(repo))
+            repo.git.push('origin', all=True, with_exceptions=True)

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -24,14 +24,14 @@ from requests import get
 from . import publish
 from .edit_functions import create_new_page, delete_file, update_page
 from .jekyll_functions import load_jekyll_doc, load_languages
-from .google_api_functions import read_ga_config, fetch_google_analytics_for_page, WriteLocked
+from .google_api_functions import read_ga_config, fetch_google_analytics_for_page
 from .repo_functions import (
     get_existing_branch, ignore_task_metadata_on_merge, get_message_classification, ChimeRepo,
     ACTIVITY_CREATED_MESSAGE, get_task_metadata_for_branch, complete_branch, abandon_branch,
     clobber_default_branch, MergeConflict, get_review_state_and_authorized, save_working_file,
     update_review_state, provide_feedback, move_existing_file, TASK_METADATA_FILENAME,
     REVIEW_STATE_EDITED, REVIEW_STATE_FEEDBACK, REVIEW_STATE_ENDORSED, REVIEW_STATE_PUBLISHED,
-    NEEDS_PUSH_FILE, _remote_exists
+    NEEDS_PUSH_FILE, mark_upstream_push_needed, _remote_exists
     )
 
 from .href import needs_redirect, get_redirect
@@ -490,12 +490,7 @@ def synch_required(route_function):
         # Push to origin only if the request method indicates a change.
         if request.method in ('PUT', 'POST', 'DELETE'):
             Logger.debug('- ' * 40)
-
-            needs_push_file = join(current_app.config['RUNNING_STATE_DIR'], NEEDS_PUSH_FILE)
-            
-            with WriteLocked(needs_push_file) as file:
-                file.truncate()
-                file.write('Yes')
+            mark_upstream_push_needed(current_app.config['RUNNING_STATE_DIR'])
 
         Logger.debug('-' * 40 + '>' * 40)
 
@@ -544,12 +539,7 @@ def synched_checkout_required(route_function):
         # Push to origin only if the request method indicates a change.
         if request.method in ('PUT', 'POST', 'DELETE'):
             Logger.debug('- ' * 40)
-
-            needs_push_file = join(current_app.config['RUNNING_STATE_DIR'], NEEDS_PUSH_FILE)
-            
-            with WriteLocked(needs_push_file) as file:
-                file.truncate()
-                file.write('Yes')
+            mark_upstream_push_needed(current_app.config['RUNNING_STATE_DIR'])
 
         Logger.debug('-' * 40 + '>' * 40)
 

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -21,18 +21,17 @@ from dateutil.relativedelta import relativedelta
 from flask import request, session, current_app, redirect, flash, render_template
 from requests import get
 
-from . import publish, NEEDS_PUSH_FILE
+from . import publish
 from .edit_functions import create_new_page, delete_file, update_page
 from .jekyll_functions import load_jekyll_doc, load_languages
 from .google_api_functions import read_ga_config, fetch_google_analytics_for_page, WriteLocked
 from .repo_functions import (
-    get_existing_branch, ignore_task_metadata_on_merge,
-    get_message_classification, ChimeRepo, ACTIVITY_CREATED_MESSAGE,
-    get_task_metadata_for_branch, complete_branch, abandon_branch,
-    clobber_default_branch, MergeConflict, get_review_state_and_authorized,
-    save_working_file, update_review_state, provide_feedback,
-    move_existing_file, TASK_METADATA_FILENAME, REVIEW_STATE_EDITED,
-    REVIEW_STATE_FEEDBACK, REVIEW_STATE_ENDORSED, REVIEW_STATE_PUBLISHED
+    get_existing_branch, ignore_task_metadata_on_merge, get_message_classification, ChimeRepo,
+    ACTIVITY_CREATED_MESSAGE, get_task_metadata_for_branch, complete_branch, abandon_branch,
+    clobber_default_branch, MergeConflict, get_review_state_and_authorized, save_working_file,
+    update_review_state, provide_feedback, move_existing_file, TASK_METADATA_FILENAME,
+    REVIEW_STATE_EDITED, REVIEW_STATE_FEEDBACK, REVIEW_STATE_ENDORSED, REVIEW_STATE_PUBLISHED,
+    NEEDS_PUSH_FILE, _remote_exists
     )
 
 from .href import needs_redirect, get_redirect
@@ -450,23 +449,6 @@ def login_required(route_function):
         return route_function(*args, **kwargs)
 
     return decorated_function
-
-def _remote_exists(repo, remote):
-    ''' Check whether a named remote exists in a repository.
-
-        This should be as simple as `remote in repo.remotes`,
-        but GitPython has a bug in git.util.IterableList:
-
-            https://github.com/gitpython-developers/GitPython/issues/11
-    '''
-    try:
-        repo.remotes[remote]
-
-    except IndexError:
-        return False
-
-    else:
-        return True
 
 def browserid_hostname_required(route_function):
     ''' Decorator for routes that enforces the hostname set in the BROWSERID_URL config variable

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -475,24 +475,11 @@ def synch_required(route_function):
     '''
     @wraps(route_function)
     def decorated_function(*args, **kwargs):
-        Logger.debug('<' * 40 + '-' * 40)
-
-        repo = Repo(current_app.config['REPO_PATH'])
-
-        if _remote_exists(repo, 'origin'):
-            Logger.debug('  fetching origin {}'.format(repo))
-            repo.git.fetch('origin', with_exceptions=True)
-
-        Logger.debug('- ' * 40)
-
         response = route_function(*args, **kwargs)
 
-        # Push to origin only if the request method indicates a change.
+        # Push upstream only if the request method indicates a change.
         if request.method in ('PUT', 'POST', 'DELETE'):
-            Logger.debug('- ' * 40)
             mark_upstream_push_needed(current_app.config['RUNNING_STATE_DIR'])
-
-        Logger.debug('-' * 40 + '>' * 40)
 
         return response
 
@@ -505,14 +492,6 @@ def synched_checkout_required(route_function):
     '''
     @wraps(route_function)
     def decorated_function(*args, **kwargs):
-        Logger.debug('<' * 40 + '-' * 40)
-
-        repo = Repo(current_app.config['REPO_PATH'])
-
-        if _remote_exists(repo, 'origin'):
-            Logger.debug('  fetching origin {}'.format(repo))
-            repo.git.fetch('origin', with_exceptions=True)
-
         checkout = get_repo(flask_app=current_app)
         # get the branch name from request.form if it's not in kwargs
         branch_name_raw = kwargs['branch_name'] if 'branch_name' in kwargs else None
@@ -532,16 +511,11 @@ def synched_checkout_required(route_function):
         branch.checkout()
 
         Logger.debug('  checked out to {}'.format(branch))
-        Logger.debug('- ' * 40)
-
         response = route_function(*args, **kwargs)
 
-        # Push to origin only if the request method indicates a change.
+        # Push upstream only if the request method indicates a change.
         if request.method in ('PUT', 'POST', 'DELETE'):
-            Logger.debug('- ' * 40)
             mark_upstream_push_needed(current_app.config['RUNNING_STATE_DIR'])
-
-        Logger.debug('-' * 40 + '>' * 40)
 
         return response
 

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -41,6 +41,10 @@ if __name__ == '__main__':
         except:
             traceback.print_exc(file=sys.stderr)
         
+        #
+        # Periodically push to upstream backup remote from origin, triggered
+        # in @synch_required and @synched_checkout_required decorators.
+        #
         try:
             push_upstream_if_needed(Repo(repo_path), running_state_dir)
         except:

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from logging import getLogger
 Logger = getLogger('chime.worker')
 
@@ -8,8 +8,13 @@ import time
 import sys
 import traceback
 
+from git import Repo
+
+from . import NEEDS_PUSH_FILE
+from .view_functions import _remote_exists
 from .google_api_functions import (
-    is_overdue_ga_config, read_ga_config, request_new_google_access_token
+    is_overdue_ga_config, read_ga_config, request_new_google_access_token,
+    WriteLocked
 )
 
 parser = argparse.ArgumentParser(description='Do the things that need doing.')
@@ -18,9 +23,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    running_state_dir, ga_client_id, ga_client_secret = \
+    running_state_dir, ga_client_id, ga_client_secret, repo_path = \
         os.environ['RUNNING_STATE_DIR'], os.environ['GA_CLIENT_ID'], \
-        os.environ['GA_CLIENT_SECRET']
+        os.environ['GA_CLIENT_SECRET'], os.environ['REPO_PATH']
 
     while True:
         #
@@ -35,6 +40,19 @@ if __name__ == '__main__':
                     running_state_dir, ga_client_id, ga_client_secret
                 )
                 request_new_google_access_token(*token_args)
+        except:
+            traceback.print_exc(file=sys.stderr)
+        
+        try:
+            needs_push_file = os.path.join(running_state_dir, NEEDS_PUSH_FILE)
+
+            if os.path.exists(needs_push_file):
+                with WriteLocked(needs_push_file) as file:
+                    repo = Repo(repo_path)
+                    if _remote_exists(repo, 'origin'):
+                        Logger.info('  pushing origin {}'.format(repo))
+                        repo.git.push('origin', all=True, with_exceptions=True)
+                    os.remove(file.name)
         except:
             traceback.print_exc(file=sys.stderr)
 

--- a/chime/worker.py
+++ b/chime/worker.py
@@ -10,11 +10,9 @@ import traceback
 
 from git import Repo
 
-from . import NEEDS_PUSH_FILE
-from .view_functions import _remote_exists
+from .repo_functions import NEEDS_PUSH_FILE, push_upstream_if_needed
 from .google_api_functions import (
-    is_overdue_ga_config, read_ga_config, request_new_google_access_token,
-    WriteLocked
+    is_overdue_ga_config, read_ga_config, request_new_google_access_token
 )
 
 parser = argparse.ArgumentParser(description='Do the things that need doing.')
@@ -44,15 +42,7 @@ if __name__ == '__main__':
             traceback.print_exc(file=sys.stderr)
         
         try:
-            needs_push_file = os.path.join(running_state_dir, NEEDS_PUSH_FILE)
-
-            if os.path.exists(needs_push_file):
-                with WriteLocked(needs_push_file) as file:
-                    repo = Repo(repo_path)
-                    if _remote_exists(repo, 'origin'):
-                        Logger.info('  pushing origin {}'.format(repo))
-                        repo.git.push('origin', all=True, with_exceptions=True)
-                    os.remove(file.name)
+            push_upstream_if_needed(Repo(repo_path), running_state_dir)
         except:
             traceback.print_exc(file=sys.stderr)
 

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -2252,6 +2252,18 @@ class TestProcess (TestCase):
             task_path, soup8 = client.leave_feedback(url=task_path, soup=soup7, feedback_str='It is super-great.')
             approved_path, soup9 = client.approve_activity(url=task_path, soup=soup8)
             published_path, soup10 = client.publish_activity(url=approved_path, soup=soup9)
+            
+            #
+            # Check with upstream repository.
+            #
+            origin_commit = self.origin.refs.master.commit.hexsha
+            upstream_commit = self.upstream.refs.master.commit.hexsha
+            self.assertNotEqual(origin_commit, upstream_commit, 'Origin and upstream should not match before explicit synch')
+            
+            running_state_dir = self.app.config['RUNNING_STATE_DIR']
+            repo_functions.push_upstream_if_needed(self.origin, running_state_dir)
+            upstream_commit = self.upstream.refs.master.commit.hexsha
+            self.assertEqual(origin_commit, upstream_commit, 'Origin and upstream should match after explicit synch')
 
             #
             # Switch back and try to make another edit, but watch it fail.


### PR DESCRIPTION
If there is a remote origin defined on the app `REPO_PATH` (e.g. Github, or some permanent directory) then push to it asynchronously when changes are made.

* [x] Add tests with upstream backup repository.
* [x] Remove `git pull` from synch decorators.
* [x] Move `git push` out of lock context.

Closes #287.