### PR TITLE
turning off git-flavored markdown for live preview

### DIFF
--- a/chime/static/javascript/markdown-previewer.js
+++ b/chime/static/javascript/markdown-previewer.js
@@ -21,6 +21,11 @@ function Editor(title, content, preview) {
   }
 
   this.init = function() {
+    // makes markdown output closer to jekyll markdown output
+    marked.setOptions({
+      gfm: false
+    })
+
   	$('.markdown-previewer').load(function() {
 	  	$(content).bind('keyup change', function(e) {
 	  		self.updateContent();


### PR DESCRIPTION
fixes #443 

I created a suite of markdown syntax errors I'm seeing in our bootcamp sites and tested live preview against the jekyll site preview.

Seems like turning off github-flavored markdown in the live preview fixes all of the discrepancies I can find so far.

@tmaybe mind taking a look at this?

![screen shot 2015-08-05 at 12 53 32 pm](https://cloud.githubusercontent.com/assets/606439/9096356/7d725fea-3b71-11e5-9003-b055e768bdef.png)
_____________________________________
![screen shot 2015-08-05 at 12 47 53 pm](https://cloud.githubusercontent.com/assets/606439/9096354/7d6f9986-3b71-11e5-851d-693d8e04af96.png)
_____________________________________
![screen shot 2015-08-05 at 12 47 47 pm](https://cloud.githubusercontent.com/assets/606439/9096357/7d730c24-3b71-11e5-8ed9-67a77ffab6a0.png)
_____________________________________
![screen shot 2015-08-05 at 12 47 49 pm](https://cloud.githubusercontent.com/assets/606439/9096355/7d72520c-3b71-11e5-8314-9b077b1ef84f.png)
