### PR TITLE
Raise 404 for missing branch

### DIFF
--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -156,16 +156,25 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
     '''
     clone.git.fetch('origin')
 
+    local_branch = get_branch_if_exists_locally(clone, default_branch_name, new_branch_name)
+    if local_branch:
+        return local_branch
+
+    # Return the branch if it exists at the origin
+    return get_branch_if_exists_at_origin(clone, default_branch_name, new_branch_name)
+
+def get_branch_if_exists_locally(clone, default_branch_name, new_branch_name):
+    ''' Return a branch if it exists locally, otherwise return None
+    '''
     start_point = get_branch_start_point(clone, default_branch_name, new_branch_name)
-    logging.debug('get_existing_branch() start_point is %s' % repr(start_point))
+    logging.debug('get_branch_if_exists_locally() start_point is %s' % repr(start_point))
 
     # See if it already matches start_point
     if new_branch_name in clone.branches:
         if clone.branches[new_branch_name].commit == start_point:
             return clone.branches[new_branch_name]
 
-    # See if the branch exists at the origin
-    return get_branch_if_exists_at_origin(clone, default_branch_name, new_branch_name)
+    return None
 
 def get_branch_if_exists_at_origin(clone, default_branch_name, new_branch_name):
     ''' Get and return a branch if it exists at the origin, otherwise return None

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -73,6 +73,7 @@ LAYOUT_PLURAL_LOOKUP = {
 
 # error messages
 MESSAGE_ACTIVITY_DELETED = u'This activity has been deleted or never existed! Please start a new activity to make changes.'
+MESSAGE_ACTIVITY_PUBLISHED = u'This activity was published {published_date} by {published_by}! Please start a new activity to make changes.'
 
 # files that match these regex patterns will not be shown in the file explorer
 FILE_FILTERS = [
@@ -568,7 +569,7 @@ def synched_checkout_required(route_function):
             commit = tag_ref.commit
             published_date = repo.git.show('--format=%ad', '--date=relative', commit.hexsha).strip()
             published_by = commit.committer.email
-            flash_only(u'This activity was published {} by {}! Please start a new activity to make changes.'.format(published_date, published_by), u'warning')
+            flash_only(MESSAGE_ACTIVITY_PUBLISHED.format(published_date=published_date, published_by=published_by), u'warning')
 
             # if the published branch doesn't exist locally, raise a 404
             if not local_branch:

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -29,7 +29,7 @@ It goes something like this:
   + `rbenv rehash`
 * Check jekyll
   + `cd ..`
-  + `jekyll/run-jekyll.sh`
+  + `jekyll/run-jekyll.sh --help`
   + Should produce the jekyll help, not error messages
 
 

--- a/test/unit/chime_test_client.py
+++ b/test/unit/chime_test_client.py
@@ -37,11 +37,11 @@ class ChimeTestClient:
         '''
         self.open_link(self.path)
 
-    def open_link(self, url):
+    def open_link(self, url, expected_status_code=200):
         ''' Open a link
         '''
         response = self.client.get(url)
-        self.test.assertEqual(response.status_code, 200)
+        self.test.assertEqual(response.status_code, expected_status_code)
 
         self.path, self.soup = url, BeautifulSoup(response.data)
 
@@ -311,7 +311,7 @@ class ChimeTestClient:
         # View the saved feedback.
         self.follow_redirect(response, 303)
 
-    def publish_activity(self, expected_code=303):
+    def publish_activity(self, expected_status_code=303):
         ''' Look for form to publish activity, submit it.
         '''
         body = self.soup.find(lambda tag: bool(tag.name == 'textarea' and tag.get('name') == 'comment_text'))
@@ -325,4 +325,4 @@ class ChimeTestClient:
         publish_activity_path = urlparse(urljoin(self.path, form['action'])).path
         response = self.client.post(publish_activity_path, data=data)
         # View the published activity.
-        self.follow_redirect(response, expected_code)
+        self.follow_redirect(response, expected_status_code)

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -2185,13 +2185,15 @@ class TestProcess (TestCase):
         ''' When someone else publishes a task you're working in, you're notified.
         '''
         with HTTMock(self.auth_csv_example_allowed):
+            erica_email = u'erica@example.com'
+            francis_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
-                erica.sign_in('erica@example.com')
+                erica.sign_in(erica_email)
 
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in('frances@example.com')
+                frances.sign_in(francis_email)
 
             # Start a new task
             erica.start_task(description='Eating Carrion', beneficiary='Vultures')
@@ -2224,20 +2226,26 @@ class TestProcess (TestCase):
             # load an edit page
             erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug))
             # a warning is flashed about working in a published branch
-            self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and u'This activity was published' in tag.text))
+            # we can't get the date exactly right, so test for every other part of the message
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=francis_email)
+            message_published_split = message_published.split(u'xxx')
+            for part in message_published_split:
+                self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
 
     # in TestProcess
     def test_page_not_found_when_branch_published(self):
         ''' When you're working in a published branch and don't have a local copy, you get a 404 error
         '''
         with HTTMock(self.auth_csv_example_allowed):
+            erica_email = u'erica@example.com'
+            francis_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
-                erica.sign_in('erica@example.com')
+                erica.sign_in(erica_email)
 
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in('frances@example.com')
+                frances.sign_in(francis_email)
 
             # Start a new task
             erica.start_task(description='Eating Carrion', beneficiary='Vultures')
@@ -2276,7 +2284,12 @@ class TestProcess (TestCase):
             # load an edit page
             erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug), expected_status_code=404)
             # a warning is flashed about working in a published branch
-            self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and u'This activity was published' in tag.text))
+            # we can't get the date exactly right, so test for every other part of the message
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=francis_email)
+            message_published_split = message_published.split(u'xxx')
+            for part in message_published_split:
+                self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
+
             # the 404 page was loaded
             pattern_template_comment_stripped = sub(ur'<!--|-->', u'', PATTERN_TEMPLATE_COMMENT)
             comments = erica.soup.find_all(text=lambda text: isinstance(text, Comment))

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -2331,7 +2331,7 @@ class TestProcess (TestCase):
             # load an edit page
             erica.open_link(url='/tree/{}/edit/other/'.format(erica_branch_name))
             # a warning is flashed about working in a deleted branch
-            self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and tag.text == view_functions.MESSAGE_ACTIVITY_DELETED))
+            self.assertIsNotNone(erica.soup.find(text=view_functions.MESSAGE_ACTIVITY_DELETED))
 
     # in TestProcess
     def test_page_not_found_when_branch_deleted(self):
@@ -2375,7 +2375,7 @@ class TestProcess (TestCase):
             # load an edit page
             erica.open_link(url='/tree/{}/edit/other/'.format(erica_branch_name), expected_status_code=404)
             # a warning is flashed about working in a deleted branch
-            self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and tag.text == view_functions.MESSAGE_ACTIVITY_DELETED))
+            self.assertIsNotNone(erica.soup.find(text=view_functions.MESSAGE_ACTIVITY_DELETED))
             # the 404 page was loaded
             pattern_template_comment_stripped = sub(ur'<!--|-->', u'', PATTERN_TEMPLATE_COMMENT)
             comments = erica.soup.find_all(text=lambda text: isinstance(text, Comment))


### PR DESCRIPTION
Trying to navigate to branches that once existed but were published or deleted *and* also no longer exist locally will raise a 404 instead of a 500. Same with branches that never existed.

Closes #446


