### PR TITLE
Add more detail to production error reports.

### DIFF
--- a/chime/chimelog.py
+++ b/chime/chimelog.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import collections
+import json
 from logging import getLogger, Handler, Formatter
 
 Logger = getLogger('chime.chimelog')
@@ -28,17 +30,70 @@ def get_filehandler(dirnames):
 
 
 ERROR_REPORT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+
+def make_safe_for_json(object, expression):
+    '''
+    Given an object and a string expression, evals the expression for the object
+    and returns the results, but only if the result can be safely represented
+    in JSON. Otherwise, return a grumbly error mesasage.
+    '''
+    try:
+        if '{}' in expression:
+            to_eval = expression.format("object")
+        else:
+            to_eval = "object.{}".format(expression)
+
+        result = eval(to_eval)
+        json.dumps(result)
+        return result
+    except Exception as e:
+        # traceback.print_exc(file=sys.stderr)
+        Logger.error("failure jsonifying {} for {}".format(expression, object))
+        return "SERIALIZATION_ERROR: For '{}': {}".format(expression, e.message)
+
+
 class ChimeErrorReportFormatter(Formatter):
+    '''
+    To make production debugging easier, this produces extensive output on failure
+    '''
     def __init__(self):
         super(ChimeErrorReportFormatter, self).__init__(ERROR_REPORT_FORMAT)
 
     def format(self, record):
         result = super(ChimeErrorReportFormatter, self).format(record)
-        if hasattr(record, 'request'):
+        if hasattr(record, 'request') and record.request:
             result += "\n\nRequest info:\n"
             result += "%s" % record.request
-            # This is a good place to add more detailed error reporting
+            result += "\n\nFull state = \n"
+            result += self.state_as_json(record)
         return result
+
+    def state_as_json(self, record):
+        '''
+        Given a request object, pull out the interesting things, convert them to JSON,
+        and return them as a pretty-print string. If an object is not JSON-serializable,
+        record the error message instead of blowing up.
+        :param request: werkzeug Request object
+        :return: pretty-printed JSON-formatted string
+        '''
+        result = collections.OrderedDict()
+        if hasattr(record, 'session') and record.session:
+            result['email'] = record.session['email']
+        if hasattr(record, 'request') and record.request:
+            request = record.request
+            for expression in ["method", "url", "referrer", "remote_addr",
+                               "content_type", "content_length", "form",
+                               "dict({}.headers)", "cookies"]:
+                result[expression] = make_safe_for_json(request, expression)
+        if hasattr(record, 'session') and record.session:
+            result['session'] = dict(record.session)
+
+        try:
+            return json.dumps(result, indent=4)
+        except Exception as e:
+            Logger.error("failure dumping state for error report", e)
+            return json.dumps({'error', e.message or "failure in json.dumps"})
 
 
 class SnsHandler(Handler):

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -456,9 +456,9 @@ def log_application_errors(route_function):
             error_code = getattr(e, 'code', 500)
 
             if error_code in range(400, 499):
-                Logger.info(e, exc_info=False, extra={'request': request})
+                Logger.info(e, exc_info=False, extra={'request': request, 'session':session})
             else:
-                Logger.error(e, exc_info=True, extra={'request': request})
+                Logger.error(e, exc_info=True, extra={'request': request, 'session':session})
 
             raise
 

--- a/test/unit/test_logs.py
+++ b/test/unit/test_logs.py
@@ -13,7 +13,7 @@ import flask
 
 import werkzeug.datastructures
 
-from chimelog import ChimeErrorReportFormatter, make_safe_for_json
+from chime.chimelog import ChimeErrorReportFormatter, make_safe_for_json
 
 repo_root = abspath(join(dirname(__file__), '..'))
 sys.path.insert(0, repo_root)


### PR DESCRIPTION
Gives a hopefully more useful production error report. Because broken error handlers are worse than no error handlers, the code tries very hard not to make things worse.