### PR TITLE
Make published branches browsable

### DIFF
--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -142,13 +142,8 @@ def get_existing_branch(clone, default_branch_name, new_branch_name):
 def get_branch_if_exists_locally(clone, default_branch_name, new_branch_name):
     ''' Return a branch if it exists locally, otherwise return None
     '''
-    start_point = get_branch_start_point(clone, default_branch_name, new_branch_name)
-    logging.debug('get_branch_if_exists_locally() start_point is %s' % repr(start_point))
-
-    # See if it already matches start_point
     if new_branch_name in clone.branches:
-        if clone.branches[new_branch_name].commit == start_point:
-            return clone.branches[new_branch_name]
+        return clone.branches[new_branch_name]
 
     return None
 

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -147,6 +147,15 @@ def get_branch_if_exists_locally(clone, default_branch_name, new_branch_name):
 
     return None
 
+def get_branch_commit_matches_tag_commit(clone, default_branch_name, new_branch_name):
+    ''' Return True if same-named branch and tag commits match
+    '''
+    if new_branch_name in clone.branches and new_branch_name in clone.tags:
+        tag_commit = clone.tags[new_branch_name].commit
+        return (clone.branches[new_branch_name].commit == tag_commit)
+
+    return False
+
 def get_branch_if_exists_at_origin(clone, default_branch_name, new_branch_name):
     ''' Get and return a branch if it exists at the origin, otherwise return None
     '''

--- a/chime/templates/activity-overview.html
+++ b/chime/templates/activity-overview.html
@@ -101,7 +101,11 @@
                 {% endif %}
             {% endif %}
 
+            {% if activity.working_state == config.WORKING_STATE_ACTIVE %}
             <p class="activity-overview__description"><a href="{{ activity.edit_path }}">Do more work on this activity</a> or {{ comment_note }}.</p>
+            {% else %}
+            <p class="activity-overview__description"><a href="{{ activity.edit_path }}">Browse this activity.</a></p>
+            {% endif %}
 
             {% if activity.review_state != config.REVIEW_STATE_PUBLISHED and activity.working_state == config.WORKING_STATE_ACTIVE %}
             <div class="activity-log-item activity-log-item--comment">

--- a/chime/templates/article-edit.html
+++ b/chime/templates/article-edit.html
@@ -52,8 +52,8 @@
         </div>
         <div class="row__right toolbar--right">
             <a href="{{ history_path }}" class="button  toolbar__item">History</a>
-            <input type="submit" class="button button--green toolbar__item" name="action" value="Preview"/>
             {% if activity.working_state == config.WORKING_STATE_ACTIVE %}
+            <input type="submit" class="button button--green toolbar__item" name="action" value="Preview"/>
             <input type="submit" class="button button--green toolbar__item" value="Save"/>
             {% endif %}
         </div>

--- a/test/unit/process.py
+++ b/test/unit/process.py
@@ -226,13 +226,15 @@ class TestProcess (TestCase):
         ''' Check edit process with a user attempting to change an activity that's been published.
         '''
         with HTTMock(self.auth_csv_example_allowed):
+            erica_email = u'erica@example.com'
+            frances_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
-                erica.sign_in('erica@example.com')
-            
+                erica.sign_in(erica_email)
+
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in('frances@example.com')
+                frances.sign_in(frances_email)
 
             # Start a new task, "Diving for Dollars", create a new category
             # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
@@ -254,12 +256,19 @@ class TestProcess (TestCase):
             frances.leave_feedback(feedback_str='It is super-great.')
             frances.approve_activity()
             frances.publish_activity()
-            
+
             #
             # Switch back and try to make another edit.
             #
             erica.open_link(article_path)
-            erica.edit_article_and_fail(title_str='Just Awful', body_str='It was the worst of times.')
+            erica.edit_article(title_str='Just Awful', body_str='It was the worst of times.')
+
+            # a warning is flashed about working in a published branch
+            # we can't get the date exactly right, so test for every other part of the message
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=frances_email)
+            message_published_split = message_published.split(u'xxx')
+            for part in message_published_split:
+                self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
 
     # in TestProcess
     def test_editing_process_with_conflicting_edit(self):
@@ -649,8 +658,9 @@ class TestProcess (TestCase):
             message_published_split = message_published.split(u'xxx')
             for part in message_published_split:
                 self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
-            # assert that trying to save an edit to the article fails
-            erica.edit_article_and_fail(title_str=article_name, body_str=u'Chase fish into shallow water to catch them.')
+
+            # submit an edit to the article
+            erica.edit_article(title_str=article_name, body_str=u'Chase fish into shallow water to catch them.')
 
             # verify that the branch exists locally and not remotely
             self.assertTrue(erica_branch_name in repo.branches)

--- a/test/unit/process.py
+++ b/test/unit/process.py
@@ -487,14 +487,14 @@ class TestProcess (TestCase):
         '''
         with HTTMock(self.auth_csv_example_allowed):
             erica_email = u'erica@example.com'
-            francis_email = u'frances@example.com'
+            frances_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
                 erica.sign_in(erica_email)
 
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in(francis_email)
+                frances.sign_in(frances_email)
 
             # Start a new task
             erica.start_task(description='Eating Carrion', beneficiary='Vultures')
@@ -528,7 +528,7 @@ class TestProcess (TestCase):
             erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug))
             # a warning is flashed about working in a published branch
             # we can't get the date exactly right, so test for every other part of the message
-            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=francis_email)
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=frances_email)
             message_published_split = message_published.split(u'xxx')
             for part in message_published_split:
                 self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
@@ -539,14 +539,14 @@ class TestProcess (TestCase):
         '''
         with HTTMock(self.auth_csv_example_allowed):
             erica_email = u'erica@example.com'
-            francis_email = u'frances@example.com'
+            frances_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
                 erica.sign_in(erica_email)
 
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in(francis_email)
+                frances.sign_in(frances_email)
 
             # Start a new task
             erica.start_task(description='Eating Carrion', beneficiary='Vultures')
@@ -586,7 +586,7 @@ class TestProcess (TestCase):
             erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug), expected_status_code=404)
             # a warning is flashed about working in a published branch
             # we can't get the date exactly right, so test for every other part of the message
-            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=francis_email)
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=frances_email)
             message_published_split = message_published.split(u'xxx')
             for part in message_published_split:
                 self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
@@ -602,14 +602,14 @@ class TestProcess (TestCase):
         '''
         with HTTMock(self.auth_csv_example_allowed):
             erica_email = u'erica@example.com'
-            francis_email = u'frances@example.com'
+            frances_email = u'frances@example.com'
             with HTTMock(self.mock_persona_verify_erica):
                 erica = ChimeTestClient(self.app.test_client(), self)
                 erica.sign_in(erica_email)
 
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
-                frances.sign_in(francis_email)
+                frances.sign_in(frances_email)
 
             # Start a new task
             task_description = u'Squeeze A School Of Fish Into A Bait Ball'
@@ -654,7 +654,7 @@ class TestProcess (TestCase):
             erica.open_link(url=erica_article_path)
             # a warning is flashed about working in a published branch
             # we can't get the date exactly right, so test for every other part of the message
-            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=francis_email)
+            message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=frances_email)
             message_published_split = message_published.split(u'xxx')
             for part in message_published_split:
                 self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))


### PR DESCRIPTION
You can now browse a published branch if you've got a local copy of it in your repository.

Closes #456 

Also, the activity overview now shows a complete history in this state, including commits representing approval and publish, partially addressing #441. This is probably a side effect of a previous commit.