### PR TITLE
Fix io error

### DIFF
--- a/chime/views.py
+++ b/chime/views.py
@@ -289,11 +289,14 @@ def branch_view(branch_name, path=None):
 def branch_edit(branch_name, path=None):
     repo = get_repo(flask_app=current_app)
     branch_name = branch_var2name(branch_name)
-    
     if repo_functions.get_conflict(repo, current_app.config['default_branch']):
         flash_unique(repo_functions.MERGE_CONFLICT_WARNING_FLASH_MESSAGE, u'warning')
 
     full_path = join(repo.working_dir, path or '.').rstrip('/')
+
+    # make sure the path points to something that exists
+    if not exists(full_path):
+        abort(404)
 
     if isdir(full_path):
         # if this is a directory representing an article, redirect to edit

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -2305,6 +2305,31 @@ class TestApp (TestCase):
             self.assertTrue(u'(123) 456-7890' in response.data)
 
     # in TestApp
+    def test_garbage_edit_url_raises_page_not_found(self):
+        ''' A 404 page is generated when we get an address that doesn't exist
+        '''
+        with HTTMock(self.auth_csv_example_allowed):
+            with HTTMock(self.mock_persona_verify_erica):
+                erica = ChimeTestClient(self.app.test_client(), self)
+                erica.sign_in('erica@example.com')
+
+            # Start a new task
+            erica.start_task(description=u'Take Malarone', beneficiary=u'People Susceptible to Malaria')
+            # Get the branch name
+            branch_name = erica.get_branch_name()
+            # Enter the "other" folder
+            other_slug = u'other'
+            erica.follow_link(href='/tree/{}/edit/{}/'.format(branch_name, other_slug))
+
+            # Create a category
+            category_name = u'Rubber Plants'
+            category_slug = slugify(category_name)
+            erica.add_category(category_name=category_name)
+
+            # Try to load a non-existent page within the category
+            erica.open_link(url='/tree/{}/edit/{}/malaria'.format(branch_name, category_slug), expected_status_code=404)
+
+    # in TestApp
     def test_internal_server_error(self):
         ''' A 500 page is generated when we provoke a server error
         '''


### PR DESCRIPTION
fixes i/o 500 errors that were being raised when adding garbage text to the end of `/edit/` URLs.

Closes #355 

