### PR TITLE
Configure acceptance tests for nightly runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
 env:
   matrix:
     - SUITE='nosetests test/unit'
-####- SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
+    - SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
   global:
     - secure: M+PrGzEfHRj+mPn7d1vHC0n/IQN6fNGER2dhG8qBE8wfC3tfaB3F50R8YSR9R5SdkdapxtgEjPgGvR3agum999qYXo839nra0zq2l3DeQYvwM0IXX0JlscwUkBrMtqMFW9iIIyxB6dgdksUJ5Zz7qcYudm+Msr15iob3DfIxZqs=
     - secure: C8Br1052Hqd+X2OS6g+x31gZtwIzWSq1M2fvGxgIWR+wqZ5IQ6NfkTD2Ht6KwtW4fMUo/41le3t+AFReQeSMZ16l7yvkC7BWcrqQOWaNXNm9Gj1t1QFMuKQvhv3NT0H6HGLXXGMrHwLKDHTCAnSOe8k/xbhqG8Og4UF0hoOF7lY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
 env:
   matrix:
     - SUITE='nosetests test/unit'
-    - SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
+####- SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
   global:
     - secure: M+PrGzEfHRj+mPn7d1vHC0n/IQN6fNGER2dhG8qBE8wfC3tfaB3F50R8YSR9R5SdkdapxtgEjPgGvR3agum999qYXo839nra0zq2l3DeQYvwM0IXX0JlscwUkBrMtqMFW9iIIyxB6dgdksUJ5Zz7qcYudm+Msr15iob3DfIxZqs=
     - secure: C8Br1052Hqd+X2OS6g+x31gZtwIzWSq1M2fvGxgIWR+wqZ5IQ6NfkTD2Ht6KwtW4fMUo/41le3t+AFReQeSMZ16l7yvkC7BWcrqQOWaNXNm9Gj1t1QFMuKQvhv3NT0H6HGLXXGMrHwLKDHTCAnSOe8k/xbhqG8Og4UF0hoOF7lY=

--- a/fabfile/fabconf.py
+++ b/fabfile/fabconf.py
@@ -11,6 +11,7 @@ best practice. See: http://lists.gnu.org/archive/html/fab-user/2013-11/msg00006.
 
 import os
 import os.path
+import pwd
 
 fabconf = {}
 
@@ -41,8 +42,10 @@ fabconf['PROJECT_PATH'] = '{apps}/{project}'.format(
 fabconf['DOMAINS'] = os.environ.get('DOMAINS')
 
 # Name tag for your server instance on EC2
+# Use recommendation from https://docs.python.org/2/library/os.html#os.getlogin 
+# to get around ioctl error thrown by os.getlogin() in a cron job.
 fabconf['INSTANCE_NAME_TAG'] = os.environ.get('INSTANCE_NAME_TAG', 'ChimeCMS Autotest')
-fabconf['INSTANCE_CREATED_BY'] = '{}-{}'.format(os.getlogin(),os.uname()[1])
+fabconf['INSTANCE_CREATED_BY'] = '{}-{}'.format(pwd.getpwuid(os.getuid())[0], os.uname()[1])
 
 # EC2 key.
 fabconf['AWS_ACCESS_KEY'] = os.environ['AWS_ACCESS_KEY']

--- a/fabfile/requirements.txt
+++ b/fabfile/requirements.txt
@@ -3,3 +3,4 @@ selenium==2.45.0
 honcho==0.6.6
 boto==2.38.0
 nose==1.3.7
+requests==2.7.0

--- a/fabfile/requirements.txt
+++ b/fabfile/requirements.txt
@@ -1,2 +1,5 @@
 Fabric==1.10.1
 selenium==2.45.0
+honcho==0.6.6
+boto==2.38.0
+nose==1.3.7

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -200,12 +200,18 @@ def _send_results_to_cloud(filename, key_name):
     ''' Send JSON results to the moon.
     '''
     with open(filename) as file:
-        headers = {'Content-Type': 'application/json'}
-        results = json.dumps([json.loads(line) for line in file], indent=2)
+        results = [json.loads(line) for line in file]
+
+    headers = {'Content-Type': 'application/json'}
+    
+    # The first and last lines have the start and end times.
+    output = dict(results=results[1:-1])
+    output.update(results[0])
+    output.update(results[-1])
 
     connection = connect_s3(fabconf.get('AWS_ACCESS_KEY'), fabconf.get('AWS_SECRET_KEY'))
     key = connection.get_bucket('chimecms-test-results').new_key(key_name)
-    key.set_contents_from_string(results, policy='public-read', headers=headers)
+    key.set_contents_from_string(output, policy='public-read', headers=headers)
     url = key.generate_url(expires_in=0, query_auth=False, force_http=True)
 
     print('Uploaded to', url)

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -320,7 +320,11 @@ def _install_chime_if_necessary():
         rsync_code()
         print(green('Running chef setup scripts...'))
         time.sleep(2)
-        run('cd chime && sudo ACCEPTANCE_TEST_MODE=1 chef/run.sh')
+
+        # Directory name needs to match current directory due to rsync:
+        # http://docs.fabfile.org/en/1.10/api/contrib/project.html#fabric.contrib.project.rsync_project
+        dirname = os.path.basename(os.path.abspath('.'))
+        run('cd {dir} && sudo ACCEPTANCE_TEST_MODE=1 chef/run.sh'.format(dir=dirname))
 
 
 def _make_sure_host_name_is_right(hostname):

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -220,7 +220,7 @@ def _send_results_to_cloud(filename, slack_webhook_url):
 
     connection = connect_s3(fabconf.get('AWS_ACCESS_KEY'), fabconf.get('AWS_SECRET_KEY'))
 
-    for key_name in ('acceptance-test-nights.json', 'acceptance-test-nights-{}.json'.format(commit)): 
+    for key_name in ('acceptance-test-nights.json', 'acceptance-test-nights-{:.0f}.json'.format(time.time())): 
         key = connection.get_bucket('chimecms-test-results').new_key(key_name)
         key.set_contents_from_string(string, policy='public-read', headers=headers)
         url = key.generate_url(expires_in=0, query_auth=False, force_http=True)

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
+import os
 import time
 
 import boto.ec2
@@ -101,10 +102,20 @@ def test_chime(setup=True, despawn=True, despawn_on_failure=False):
     print(green('Running tests...'))
     time.sleep(2)
     try:
+        OUTPUT_FILE = os.environ.get('OUTPUT_FILE')
+        if OUTPUT_FILE:
+            with open(OUTPUT_FILE, 'w') as output:
+                print('Starting...', file=output)
         local('nosetests  --processes=9 --process-timeout=300 ' + fabconf.get('FAB_CONFIG_PATH') + '/../test/acceptance')
+        if OUTPUT_FILE:
+            with open(OUTPUT_FILE, 'a') as output:
+                print('...all done.', file=output)
         if _looks_true(despawn):
             _despawn(public_dns)
     except:
+        if OUTPUT_FILE:
+            with open(OUTPUT_FILE, 'a') as output:
+                print('...failed', file=output)
         if _looks_true(despawn_on_failure):
             _despawn(public_dns)
         raise
@@ -157,6 +168,9 @@ def _load_hosts():
         return [h.strip() for h in hosts if h != '']
     except IOError:
         return []
+
+        if self.output:
+            print(self, 'done', file=self.output)
 
 
 def _write_host_to_file(host):

--- a/test/acceptance/test_preview.py
+++ b/test/acceptance/test_preview.py
@@ -36,6 +36,7 @@ class TestPreview(ChimeTestCase):
         self.host = self.load_hosts_file()[0]
         self.live_site = 'http://' + self.host
         if OUTPUT_FILE:
+            self.browser = None
             self.started = time.time()
             self.status = 'started'
 
@@ -97,6 +98,8 @@ class TestPreview(ChimeTestCase):
 
     def test_create_page_and_preview(self, browser=None):
         self.use_driver(browser)
+        if OUTPUT_FILE:
+            self.browser = ' '.join([browser.os, browser.os_version, browser.browser, browser.browser_version])
 
         signin_method = "stubby_js"
         if signin_method=='magic_url':
@@ -225,7 +228,7 @@ class TestPreview(ChimeTestCase):
             self.driver.quit()
         if OUTPUT_FILE:
             elapsed = time.time() - self.started
-            self.status.update(dict(test=repr(self), elapsed=elapsed))
+            self.status.update(dict(elapsed=elapsed, browser=self.browser))
             line = json.dumps(self.status)
             with open(OUTPUT_FILE, 'a') as file:
                 print(line, file=file)


### PR DESCRIPTION
Acceptance tests now upload data [to S3 in a publicly-accessible JSON file](http://chimecms-test-results.s3.amazonaws.com/acceptance-test-nights.json).

* [x] Make upload happen only when specifically requested, i.e. not from Travis-driven runs.
* [x] Save archived test results.

Sample data:

```JSON
[
  {
    "start": 1440721931.888421
  }, 
  {
    "status": "done", 
    "browser": "Windows 7 IE 9.0", 
    "ok": true, 
    "elapsed": 120.39418697357178
  }, 
  {
    "status": "errored", 
    "browser": "Windows 8.1 Firefox 35.0", 
    "exception": "(<class 'selenium.common.exceptions.NoSuchElementException'>, NoSuchElementException(), <traceback object at 0x7fef36cd8488>)", 
    "ok": false, 
    "elapsed": 123.96230697631836
  }, 
  {
    "status": "failed", 
    "browser": "Windows 7 IE 8.0", 
    "exception": "(<type 'exceptions.AssertionError'>, AssertionError('\\'You deleted\\' not found in u\"Saved changes to the article-916104 article! Remember to submit this change for feedback when you\\'re ready to go live.\"',), <traceback object at 0x7fef36cf3cf8>)", 
    "ok": false, 
    "elapsed": 148.9050600528717
  }, 
  {
    "ok": false, 
    "end": 1440722146.508441
  }
]
```