### PR TITLE
Turned off Browserstack in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
 env:
   matrix:
     - SUITE='nosetests test/unit'
-    - SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
+### - SUITE='env BROWSERS_TO_TEST=supported TEST_RETRY_COUNT=3 fab test_chime:despawn_on_failure=t'
   global:
     - secure: M+PrGzEfHRj+mPn7d1vHC0n/IQN6fNGER2dhG8qBE8wfC3tfaB3F50R8YSR9R5SdkdapxtgEjPgGvR3agum999qYXo839nra0zq2l3DeQYvwM0IXX0JlscwUkBrMtqMFW9iIIyxB6dgdksUJ5Zz7qcYudm+Msr15iob3DfIxZqs=
     - secure: C8Br1052Hqd+X2OS6g+x31gZtwIzWSq1M2fvGxgIWR+wqZ5IQ6NfkTD2Ht6KwtW4fMUo/41le3t+AFReQeSMZ16l7yvkC7BWcrqQOWaNXNm9Gj1t1QFMuKQvhv3NT0H6HGLXXGMrHwLKDHTCAnSOe8k/xbhqG8Og4UF0hoOF7lY=


### PR DESCRIPTION
During September, we have an expanded suite of Browserstack tests running twice-daily. This PR removes Browserstack from the CI loop for that time.