### PR TITLE
suppressing some useless test output

### DIFF
--- a/chime/jekyll_functions.py
+++ b/chime/jekyll_functions.py
@@ -144,7 +144,7 @@ def build_jekyll_site(dirname):
     project_dir = os.path.join(python_dir, "..")
     jekyll_script = os.path.realpath(os.path.join(project_dir, 'jekyll/run-jekyll.sh'))
 
-    call = [jekyll_script, 'build']
+    call = [jekyll_script, 'build', '--quiet']
     try:
         build = Popen(call, cwd=dirname)
         build.wait()

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -961,9 +961,6 @@ def publish_commit(repo, publish_path):
 
         # http://stackoverflow.com/questions/4479960/git-checkout-to-a-specific-folder
         environ['GIT_WORK_TREE'], old_GWT = checkout_dir, environ.get('GIT_WORK_TREE')
-        sys.stderr.write("Git work tree is {}\n".format(environ['GIT_WORK_TREE']))
-        sys.stderr.write("Repo {}\n".format(repr(repo)))
-        sys.stderr.write("Hexsha {}\n".format(repo.commit().hexsha))
         repo.git.checkout(repo.commit().hexsha, '.')
 
         built_dir = build_jekyll_site(checkout_dir)

--- a/jekyll/Gemfile.lock
+++ b/jekyll/Gemfile.lock
@@ -80,6 +80,3 @@ DEPENDENCIES
   directory-structure-generator!
   jekyll
   therubyracer
-
-BUNDLED WITH
-   1.10.6

--- a/test/unit/test_logs.py
+++ b/test/unit/test_logs.py
@@ -225,8 +225,6 @@ class TestLogger(LogTestCase):
             erica.open_link_blindly(url='/fail')
 
         self.assertEqual(1, len(cm.output))
-        sys.stderr.write(cm.output[0])
-        sys.stderr.write("\n")
 
         self.assertTrue(hasattr(cm.records[0], 'request'))
         self.assertRegexpMatches(cm.output[0], '.*ERROR.*blow up.*')


### PR DESCRIPTION
Currently our tests are pretty noisy. Unless there are actual errors, I'd rather see a soothing row of dots. This gets everything but two bits of jibber-jabber coming from down in a publishing call somewhere.