### PR TITLE
Strip whitespace from task description

### DIFF
--- a/chime/views.py
+++ b/chime/views.py
@@ -206,7 +206,7 @@ def authorization_failed():
 @synch_required
 def start_branch():
     repo = get_repo(flask_app=current_app)
-    task_description = request.form.get('task_description').strip()
+    task_description = sub(r'\s+', ' ', request.form.get('task_description')).strip()
     master_name = current_app.config['default_branch']
 
     # require a task description


### PR DESCRIPTION
Now that the task description entry form has a text area you can submit task descriptions with all kinds of crazy whitespace. This strips all excessive whitespace from submitted task descriptions.
