### PR TITLE
Group activities by status #517

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ga_config.json
 .idea
 *.iml
 apache
+*.lock
 
 hosts.txt
 .sass-cache

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -72,11 +72,6 @@ class ChimeActivity:
 
         return self._working_state
 
-    def review_state(self):
-        ''' Get the activity review state
-        '''
-        return self._review_state
-
     def _make_history(self):
         ''' Make an easily-parsable history of the activity since it was created.
         '''

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -27,7 +27,7 @@ class ChimeActivity:
             working_branch_name=self.safe_branch, actor_email=actor_email
         )
 
-        self.date_created = self.repo.git.log(self.safe_branch, '-1', '--format=%ad', '--date=relative', '--', repo_functions.TASK_METADATA_FILENAME)
+        self.date_created = self.repo.git.log(self.safe_branch, '--format=%ad', '--date=relative', '--', repo_functions.TASK_METADATA_FILENAME).split('\n')[-1]
         self.date_updated = self.repo.git.log(self.safe_branch, '-1', '--format=%ad', '--date=relative')
 
         # the email of the last person who edited the activity

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -27,8 +27,8 @@ class ChimeActivity:
             working_branch_name=self.safe_branch, actor_email=actor_email
         )
 
-        self.date_created = self.repo.git.log('--format=%ad', '--date=relative', '--', repo_functions.TASK_METADATA_FILENAME).split('\n')[-1]
-        self.date_updated = self.repo.git.log('--format=%ad', '--date=relative').split('\n')[0]
+        self.date_created = self.repo.git.log(self.safe_branch, '-1', '--format=%ad', '--date=relative', '--', repo_functions.TASK_METADATA_FILENAME)
+        self.date_updated = self.repo.git.log(self.safe_branch, '-1', '--format=%ad', '--date=relative')
 
         # the email of the last person who edited the activity
         self.last_edited_email = repo_functions.get_last_edited_email(

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -72,6 +72,11 @@ class ChimeActivity:
 
         return self._working_state
 
+    def review_state(self):
+        ''' Get the activity review state
+        '''
+        return self._review_state
+
     def _make_history(self):
         ''' Make an easily-parsable history of the activity since it was created.
         '''

--- a/chime/static/images/chime_symbol.svg
+++ b/chime/static/images/chime_symbol.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="144px" height="144px" viewBox="0 0 144 144" enable-background="new 0 0 144 144" xml:space="preserve">
+<g>
+	<path fill="#DBDBDB" d="M72,53.188c-10.373,0-18.812,8.439-18.812,18.812c0,10.372,8.439,18.812,18.812,18.812
+		S90.811,82.372,90.811,72C90.811,61.627,82.372,53.188,72,53.188z"/>
+	<path fill="#DBDBDB" d="M72,40.48c-17.38,0-31.52,14.14-31.52,31.52S54.62,103.52,72,103.52c17.38,0,31.52-14.14,31.52-31.52
+		S89.38,40.48,72,40.48z M72,96.466c-13.49,0-24.466-10.976-24.466-24.466S58.509,47.535,72,47.535
+		c13.49,0,24.465,10.975,24.465,24.465S85.489,96.466,72,96.466z"/>
+	<path fill="#DBDBDB" d="M72,25.76c-25.497,0-46.24,20.743-46.24,46.24c0,25.497,20.743,46.239,46.24,46.239
+		c25.497,0,46.24-20.742,46.24-46.239C118.239,46.503,97.496,25.76,72,25.76z M72,109.174c-20.498,0-37.173-16.676-37.173-37.174
+		c0-20.498,16.676-37.174,37.173-37.174S109.173,51.502,109.173,72C109.173,92.498,92.497,109.174,72,109.174z"/>
+	<path fill="#DBDBDB" d="M72,3C33.892,3,3,33.893,3,72s30.893,69,69,69c38.108,0,69-30.893,69-69S110.107,3,72,3z M72,123.894
+		c-28.614,0-51.894-23.279-51.894-51.894S43.385,20.106,72,20.106c28.614,0,51.894,23.279,51.894,51.894S100.613,123.894,72,123.894
+		z"/>
+</g>
+<g>
+	<defs>
+		<path id="SVGID_1_" d="M3,72c0,38.107,30.892,69,69,69c38.107,0,69-30.893,69-69c0-38.108-30.893-69-69-69C33.892,3,3,33.892,3,72
+			"/>
+	</defs>
+	<clipPath id="SVGID_2_">
+		<use xlink:href="#SVGID_1_"  overflow="visible"/>
+	</clipPath>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="54.598" y="70.646" fill="#7B7B7B" width="34.804" height="90.172"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="26.37" y="98.664" fill="#7B7B7B" width="24.184" height="82.886"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="31.801" y="105.346" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="41.308" y="105.346" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="31.801" y="118.092" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="41.308" y="118.092" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="93.445" y="84.261" fill="#7B7B7B" width="24.185" height="82.886"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="61.914" y="98.647" fill="#DBDBDB" width="5.979" height="8.717"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="75.107" y="98.647" fill="#DBDBDB" width="5.979" height="8.717"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="61.914" y="117.814" fill="#DBDBDB" width="5.979" height="8.716"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="75.107" y="117.814" fill="#DBDBDB" width="5.979" height="8.716"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="61.914" y="79.481" fill="#DBDBDB" width="5.979" height="8.716"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="75.107" y="79.481" fill="#DBDBDB" width="5.979" height="8.716"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="98.554" y="105.346" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="108.061" y="105.346" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="98.554" y="92.058" fill="#DBDBDB" width="4.461" height="6.549"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="108.061" y="92.058" fill="#DBDBDB" width="4.461" height="6.549"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="98.554" y="118.092" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+	<g clip-path="url(#SVGID_2_)">
+		<rect x="108.061" y="118.092" fill="#DBDBDB" width="4.461" height="6.55"/>
+	</g>
+</g>
+</svg>

--- a/chime/static/javascript/activities-list.js
+++ b/chime/static/javascript/activities-list.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+	$('.button--new-activity').click(function(e) {
+		e.preventDefault();
+		$('.new-activity').parent().addClass('is-open');
+		$('.new-activity textarea').focus();
+	})
+	$('.button--close-modal').click(function(e) {
+		e.preventDefault();
+		$('.new-activity').parent().removeClass('is-open');
+	})
+})

--- a/chime/static/sass/components/_activity-progress.scss
+++ b/chime/static/sass/components/_activity-progress.scss
@@ -1,6 +1,5 @@
 .activity-overview__main .activity-progress.row {
 	@include clearfix();
-	font-size: $h4-font-size;
 	margin: 0;
 	margin-top: -1px;
 	padding: {
@@ -16,11 +15,11 @@
 		content: '';
 		display: block;
 		position: absolute;
-		top: 1em;
+		top: 1.25em;
 		left: -50%;
 		right: 50%;
-		margin-right: 1.4em;
-		margin-left: 1.4em;
+		margin-right: 2em;
+		margin-left: 2em;
 		height: 2px;
 		margin-top: -2px;
 		background-color: $color-grey-200;
@@ -71,13 +70,14 @@
 }
 
 .activity-progress__label {
-	font-size: $base-font-size;
+	font-size: $h4-font-size;
 	color: $color-grey-500;
 	font-weight: 300;
+	margin-top: .5em;
 	margin-bottom: 0;
 	.is-completed & {
 		color: #000;
-		font-weight: 600;
+		font-weight: 400;
 	}
 }
 
@@ -86,10 +86,10 @@
 	position: relative;
 	z-index: 1;
 	border-radius: 50%;
-	height: 2em;
-	width: 2em;
+	height: 2.5em;
+	width: 2.5em;
 	text-align: center;
-	line-height: 2em;
+	line-height: 2.5em;
 	border: 2px solid $color-grey-300;
 	color: $color-grey-500;
 	&:before {

--- a/chime/static/sass/components/_activity-progress.scss
+++ b/chime/static/sass/components/_activity-progress.scss
@@ -43,6 +43,9 @@
 		&:before {
 			background-color: $color-grey-600;
 		}
+		&:after {
+			@include triangle(right, $color-grey-600, 6px);
+		}
 	}
 	&--edited {
 		&.is-completed {
@@ -93,7 +96,6 @@
 .activity-progress__icon {
 	display: inline-block;
 	position: relative;
-	z-index: 1;
 	border-radius: 50%;
 	height: 2.5em;
 	width: 2.5em;
@@ -113,7 +115,6 @@
 	}
 	.activity-progress__item--requested & {
 		&:before {
-			top: -2px;
 			content: '\f06e';
 		}
 	}

--- a/chime/static/sass/components/_activity-progress.scss
+++ b/chime/static/sass/components/_activity-progress.scss
@@ -15,7 +15,7 @@
 		content: '';
 		display: block;
 		position: absolute;
-		top: 1.25em;
+		top: 1.3em;
 		left: -50%;
 		right: 50%;
 		margin-right: 2em;
@@ -25,8 +25,17 @@
 		background-color: $color-grey-200;
 		z-index: 0;
 	}
+	&:after {
+		position: absolute;
+		display: block;
+		top: 1.3em;
+		margin-top: -7px;
+		right: 50%;
+		margin-right: 1.8em;
+		@include triangle(right, $color-grey-300, 6px);
+	}
 	&:first-child {
-		&:before {
+		&:before, &:after {
 			display: none;
 		}
 	}
@@ -70,7 +79,7 @@
 }
 
 .activity-progress__label {
-	font-size: $h4-font-size;
+	font-size: $h5-font-size;
 	color: $color-grey-500;
 	font-weight: 300;
 	margin-top: .5em;

--- a/chime/static/sass/components/_activity-progress.scss
+++ b/chime/static/sass/components/_activity-progress.scss
@@ -1,10 +1,9 @@
-.activity-progress {
+.activity-overview__main .activity-progress.row {
 	@include clearfix();
 	font-size: $h4-font-size;
 	margin: 0;
 	margin-top: -1px;
 	padding: {
-		bottom: 1.5em;
 		right: 0;
 		left: 0;
 	}
@@ -20,7 +19,9 @@
 		top: 1em;
 		left: -50%;
 		right: 50%;
-		height: 4px;
+		margin-right: 1.4em;
+		margin-left: 1.4em;
+		height: 2px;
 		margin-top: -2px;
 		background-color: $color-grey-200;
 		z-index: 0;
@@ -32,7 +33,39 @@
 	}
 	&.is-completed {
 		&:before {
-			background-color: $color-green-300;
+			background-color: $color-grey-600;
+		}
+	}
+	&--edited {
+		&.is-completed {
+			.activity-progress__icon {
+				border-color: $color-grey-700;
+				color: $color-grey-700;
+			}
+		}
+	}
+	&--requested {
+		&.is-completed {
+			.activity-progress__icon {
+				border-color: $color-orange-300;
+				color: $color-orange-300;
+			}
+		}
+	}
+	&--endorsed {
+		&.is-completed {
+			.activity-progress__icon {
+				border-color: $color-green-300;
+				color: $color-green-300;
+			}
+		}
+	}
+	&--published {
+		&.is-completed {
+			.activity-progress__icon {
+				border-color: $color-blue-300;
+				color: $color-blue-300;
+			}
 		}
 	}
 }
@@ -49,19 +82,41 @@
 }
 
 .activity-progress__icon {
+	display: inline-block;
 	position: relative;
 	z-index: 1;
-	padding: .5em;
 	border-radius: 50%;
 	height: 2em;
 	width: 2em;
 	text-align: center;
-	line-height: 1em;
-	background-color: $color-grey-200;
+	line-height: 2em;
+	border: 2px solid $color-grey-300;
 	color: $color-grey-500;
-	.is-completed & {
-		background-color: $color-green-400;
-		color: #fff;
+	&:before {
+		font-family: "FontAwesome";
+		position: relative;
+		top: -1px;
+	}
+	.activity-progress__item--edited & {
+		&:before {
+			content: '\f040';
+		}
+	}
+	.activity-progress__item--requested & {
+		&:before {
+			top: -2px;
+			content: '\f06e';
+		}
+	}
+	.activity-progress__item--endorsed & {
+		&:before {
+			content: '\f087';
+		}
+	}
+	.activity-progress__item--published & {
+		&:before {
+			content: '\f00c';
+		}
 	}
 
 }

--- a/chime/static/sass/components/_buttons.scss
+++ b/chime/static/sass/components/_buttons.scss
@@ -114,11 +114,9 @@
 .button--text {
 	background-color: transparent;
 	border: 1px solid transparent;
-	border-radius: 0;
 	&:hover, &:active, &.is-selected {
-		background-color: transparent;
-		border-color: transparent;
-		border-bottom: 1px solid #000;
+		background-color: $color-grey-300;
+		border-color: $color-grey-300;
 		color: #000;
 	}
 }

--- a/chime/static/sass/components/_buttons.scss
+++ b/chime/static/sass/components/_buttons.scss
@@ -121,6 +121,13 @@
 	}
 }
 
+.button--nostyle {
+	background: none;
+	border: 0;
+	padding: 0;
+	color: inherit;
+}
+
 .button--medium {
 	font-size: $base-font-size;
 	padding: .5em 1em;

--- a/chime/static/sass/components/_modal.scss
+++ b/chime/static/sass/components/_modal.scss
@@ -1,5 +1,5 @@
 .modal-container {
-	@include transition(opacity .2s ease-out, margin-top .1s ease-out);
+	@include animation(modal-container .2s ease-out);
 	@include display(flex);
 	@include justify-content(center);
 	@include align-items(center);
@@ -10,17 +10,19 @@
 	right: 0;
 	background-color: $color-grey-800;
 	background-color: rgba(#000, .15);
-	z-index: -2;
 	opacity: 0;
 	margin-top: -2em;
+	display: none;
 	&.is-open {
+		display: block;
+		display: flex;
 		margin-top: 0;
-		z-index: 9999;
 		opacity: 1;
 	}
 }
 .modal {
 	@include clearfix();
+	@include animation(modal .2s ease-out);
 	background-color: #fff;
 	box-shadow: $box-shadow-2;
 	width: 600px;

--- a/chime/static/sass/components/_modal.scss
+++ b/chime/static/sass/components/_modal.scss
@@ -1,0 +1,33 @@
+.modal-container {
+	@include transition(opacity .2s ease-out, margin-top .1s ease-out);
+	@include display(flex);
+	@include justify-content(center);
+	@include align-items(center);
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background-color: $color-grey-800;
+	background-color: rgba(#000, .15);
+	z-index: -2;
+	opacity: 0;
+	margin-top: -2em;
+	&.is-open {
+		margin-top: 0;
+		z-index: 9999;
+		opacity: 1;
+	}
+}
+.modal {
+	@include clearfix();
+	background-color: #fff;
+	box-shadow: $box-shadow-2;
+	width: 600px;
+	margin: 0 auto;
+	height: auto;
+	padding: $site-margins/2;
+	.lt-ie10 & {
+		margin-top: 4em;
+	}
+}

--- a/chime/static/sass/components/_tooltip.scss
+++ b/chime/static/sass/components/_tooltip.scss
@@ -1,0 +1,40 @@
+.tooltipped {
+	position: relative;
+	&:hover {
+		.tooltipped__tt-container {
+			@include animation(tooltip .2s ease-out);
+			display: block;
+			top: 100%;
+			opacity: 1;
+		}
+	}
+}
+
+.tooltipped__tt-container {
+	display: none;
+	position: absolute;
+	left: 50%;
+	top: 120%;
+	margin-top: 6px;
+}
+
+.tooltipped__tt {
+	position: relative;
+	left: -50%;
+	background-color: $color-grey-200;
+	border: 1px solid $color-grey-300;
+	color: #000;
+	line-height: 2em;
+	padding: .3em .7em;
+	text-align: center;
+	font-weight: 400;
+	font-size: $small-font-size;
+
+	&:before {
+		position: absolute;
+		left: 50%;
+		margin-left: -5px;
+		top: -8px;
+		@include triangle(top, $color-grey-300, 5px);
+	}
+}

--- a/chime/static/sass/components/_tooltip.scss
+++ b/chime/static/sass/components/_tooltip.scss
@@ -1,7 +1,7 @@
 .tooltipped {
 	position: relative;
 	&:hover {
-		.tooltipped__tt-container {
+		.tooltipped__tt {
 			@include animation(tooltip .2s ease-out);
 			display: block;
 			top: 100%;
@@ -10,17 +10,13 @@
 	}
 }
 
-.tooltipped__tt-container {
+.tooltipped__tt {
+	@include transform(translateX(-50%));
 	display: none;
 	position: absolute;
 	left: 50%;
 	top: 120%;
 	margin-top: 6px;
-}
-
-.tooltipped__tt {
-	position: relative;
-	left: -50%;
 	background-color: $color-grey-200;
 	border: 1px solid $color-grey-300;
 	color: #000;
@@ -29,6 +25,7 @@
 	text-align: center;
 	font-weight: 400;
 	font-size: $small-font-size;
+	z-index: 9999;
 
 	&:before {
 		position: absolute;
@@ -36,5 +33,14 @@
 		margin-left: -5px;
 		top: -8px;
 		@include triangle(top, $color-grey-300, 5px);
+	}
+
+	// Different treatment of tooltips to get around lack of translateX support for <IE10
+	// Tooltip is not centered in this case but aligned left
+	.lt-ie10 & {
+		margin-left: -50%;	
+		&:before {
+			left: 5px;
+		}
 	}
 }

--- a/chime/static/sass/core/_animations.scss
+++ b/chime/static/sass/core/_animations.scss
@@ -6,3 +6,18 @@
 		@include transform(rotate(359deg));
 	}
 }
+
+@include keyframes(tooltip) {
+	0% {
+	   display: none;
+	   opacity: 0;
+	   top: 110%
+	 }
+	 1% {
+	   display: block;
+	 }
+	 100% {
+	   opacity: 1;
+	   top: 100%;
+	 }
+}

--- a/chime/static/sass/core/_animations.scss
+++ b/chime/static/sass/core/_animations.scss
@@ -21,3 +21,31 @@
 	   top: 100%;
 	 }
 }
+
+@include keyframes(modal-container) {
+	0% {
+	   display: none;
+	   opacity: 0;
+	 }
+	 1% {
+	   display: block;
+	 }
+	 100% {
+	   opacity: 1;
+	 }
+}
+
+@include keyframes(modal) {
+	0% {
+	   display: none;
+	   opacity: 0;
+	   margin-top: 4em;
+	 }
+	 1% {
+	   display: block;
+	 }
+	 100% {
+	   opacity: 1;
+	   margin-top: 0;
+	 }
+}

--- a/chime/static/sass/core/_utilities.scss
+++ b/chime/static/sass/core/_utilities.scss
@@ -25,7 +25,6 @@
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-#{opposite-position($direction)}: ($size * 1.5) solid $color;
   
   $perpendicular-borders: $size solid transparent;

--- a/chime/static/sass/main.scss
+++ b/chime/static/sass/main.scss
@@ -32,6 +32,7 @@
 @import 'components/table';
 @import 'components/forms';
 @import 'components/buttons';
+@import 'components/modal';
 @import 'components/alerts';
 @import 'components/breadcrumbs';
 @import 'components/dropdown-nav';

--- a/chime/static/sass/main.scss
+++ b/chime/static/sass/main.scss
@@ -33,6 +33,7 @@
 @import 'components/forms';
 @import 'components/buttons';
 @import 'components/modal';
+@import 'components/tooltip';
 @import 'components/alerts';
 @import 'components/breadcrumbs';
 @import 'components/dropdown-nav';

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -12,8 +12,13 @@
 
 .activity-list__states {
 	padding: 1em 0;
-	.activity-progress__item:before {
-		background-color: $color-grey-300;
+	.activity-progress__item {
+		&:before {
+			background-color: $color-grey-300;
+		}
+		&:after {
+			@include triangle(right, $color-grey-300, 6px);
+		}		
 	}
 	.activity-progress__label {
 		font-weight: 300;
@@ -33,6 +38,7 @@
 	padding: 0 $site-margins/2 2em $site-margins/2;
 	border-right: 1px solid $color-grey-200;
 	overflow: auto;
+	overflow-x: hidden;
 	&:last-child {
 		border-right: 0;
 	}

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -31,7 +31,7 @@
 	width: 250px;
 	float: left;
 	padding: 0 $site-margins/2 2em $site-margins/2;
-	border-right: 1px solid $color-grey-300;
+	border-right: 1px solid $color-grey-200;
 	overflow: auto;
 	&:last-child {
 		border-right: 0;
@@ -110,12 +110,12 @@
 	padding: 1em 0;
 	background-color: #fff;
 	box-shadow: $box-shadow-1;
-	padding: $site-margins/4 $site-margins/2;
+	padding: $site-margins/4;
 	margin: .2em 0 1em 0;
 }
 
 .activity--edited {
-	border-left: 4px solid $color-grey-300;
+	border-left: 4px solid $color-grey-600;
 }
 
 .activity--feedback {
@@ -143,12 +143,22 @@
 .activity__author {
 	margin: 0;
 	font-size: $base-font-size;
-	color: $color-grey-700;
+	color: $color-grey-500;
+	font-weight: 400;
 }
 
 .activity__actions {
+	width: auto;
 	margin-top: .5em;
-	border-top: 1px solid $color-grey-300;
+	margin: {
+		left: -$site-margins/4;
+		right: -$site-margins/4;
+	}
+	padding: {
+		left: $site-margins/4;
+		right: $site-margins/4;
+	}
+	border-top: 1px solid $color-grey-200;
 	padding-top: .5em;
 	.toolbar__item {
 		color: $color-grey-400;

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -107,9 +107,13 @@
 }
 
 .activity-box__empty-state {
-	font-size: $h4-font-size;
-	text-align: center;
-	color: $color-grey-600;
+	height: 6em;
+	width: 6em;
+	text-indent: -9999px;
+	margin: 3em auto;
+	opacity: .3;
+	background: url('../images/chime_symbol.svg') no-repeat center center;
+	background-size: 6em 6em;
 }
 
 .activity {

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -1,93 +1,145 @@
+.activities-list__header {
+	background-color: #fff;
+	border-bottom: 1px solid $color-grey-300;
+	p {
+		margin: .4em 0 0 0;
+	}
+}
+
 .activities-list__main {
-	@include main-padding();
 	@include stretch-content();
+	padding: 0 $site-margins/2;
 	background-color: $color-grey-50;
 	overflow: auto;
 }
 
-.current-tasks__empty-description {
-	font-size: $h2-font-size;
-	font-weight: 300;
-	max-width: 500px;
-	margin-top: 4em;
+.activity-box {
+	@include flex(1 1 250px);
+	width: 250px;
+	float: left;
+	padding: 2em $site-margins/2;
+	border-right: 1px solid $color-grey-300;
+	overflow: auto;
+	&:last-child {
+		border-right: 0;
+	}
 }
 
-.current-tasks__list {
-	margin: 2em 0;
-	margin-right: $site-margins/2;
+.new-activity {
+	width: 480px;
+	h3 {
+		margin-top: 0;
+	}
+	textarea {
+		font-size: $h4-font-size;
+		resize: none;
+		padding: .5em;
+	}
+	.grid {
+		button[type="submit"] {
+			margin-top: 1.4em;
+		}
+		p {
+			padding-left: 2em;
+		}
+	}
+
 }
 
-.current-task {
-	@include transition(box-shadow ease-out .2s);
-	display: block;
-	padding: .5em 1em;
+.activity-box__title {
+	font-size: $h4-font-size;
+	font-weight: 400;
+	margin-top: 0;
+	margin-bottom: 2em;
+	position: relative;
+	&:before {
+		display: inline-block;
+		margin-right: .5em;
+		font-family: "FontAwesome"
+	}
+}
+
+.activity-box__title--edited {
+	&:before {
+		content: '\f040';
+	}
+}
+
+.activity-box__title--feedback {
+	&:before {
+		content: '\f087';
+	}
+}
+
+.activity-box__title--endorsed {
+	&:before {
+		content: '\f040';
+	}
+}
+
+.activity-box__title--published {
+	&:before {
+		content: '\f00c';
+	}
+}
+
+.activity-box__list {
+	margin-top: 0;
+}
+
+.activity-box__empty-state {
+	font-size: $h4-font-size;
+	text-align: center;
+	color: $color-grey-600;
+}
+
+.activity {
+	padding: 1em 0;
 	background-color: #fff;
 	box-shadow: $box-shadow-1;
-	margin-bottom: 2em;
-	.lt-ie10 & {
-		border: 1px solid $color-grey-200;
-	}
+	padding: $site-margins/4 $site-margins/2;
+	margin: 1em 0;
 }
 
-.current-task__title {
-	font-size: $h2-font-size;
-	border-bottom: 1px solid $color-grey-100;
-	margin-top: .5em;
-	margin-bottom: .5em;
-	padding-bottom: .5em;
+.activity--edited {
+	border-left: 4px solid $color-grey-300;
+}
+
+.activity--feedback {
+	border-left: 4px solid $color-orange-300;
+}
+
+.activity--endorsed {
+	border-left: 4px solid $color-green-300;
+}
+
+.activity--published {
+	border-left: 4px solid $color-blue-300;
+}
+
+.activity__title {
+	font-weight: 400;
+	font-size: $h4-font-size;
+	margin: 0;
+	margin-bottom: .2em;
 	a {
-		color: $color-grey-900;
-		display: block;
-		position: relative;
-		&:after {
-			content: '\f105';
-			font-family: "FontAwesome";
-			position: absolute;
-			display: block;
-			right: 0;
-			top: 0;
-		}
+		color: #000;
+	}
+}
+
+.activity__author {
+	margin: 0;
+	font-size: $base-font-size;
+}
+
+.activity__actions {
+	margin-top: .5em;
+	border-top: 1px solid $color-grey-300;
+	padding-top: .5em;
+	a {
+		color: $color-grey-400;
 		&:hover {
-			color: $color-link;
-			text-decoration: none;
+			color: $color-grey-600;
 		}
 	}
 }
-
-.current-task__author {
-	margin-top: 0;
-}
-
-.current-task__details {
-	padding: 0;
-}
-
-.new-task {
-	padding: 0 $site-margins/2;
-	border-left: 1px solid $color-grey-200;
-	input {
-		margin: .5em 0;
-	}
-}
-
-.new-task__description {
-	margin-top: 0;
-	font-weight: bold;
-}
-
-.new-task__form {
-	margin-top: 5em;
-	background-color: $color-grey-100;
-	border: 1px solid $color-grey-300;
-	padding: 1em;
-}
-
-.new-task__textarea {
-	resize: none;
-	padding: .5em;
-}
-
-.new-task__actions {
-	margin-top: 1em;
-}
-

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -1,3 +1,7 @@
+.activities-list {
+	background-color: $color-grey-50;
+}
+
 .activities-list__header {
 	background-color: #fff;
 	border-bottom: 1px solid $color-grey-300;
@@ -6,10 +10,19 @@
 	}
 }
 
+.activity-list__states {
+	padding: 1em 0;
+	.activity-progress__item:before {
+		background-color: $color-grey-300;
+	}
+	.activity-progress__label {
+		font-weight: 300;
+	}
+}
+
 .activities-list__main {
 	@include stretch-content();
 	padding: 0 $site-margins/2;
-	background-color: $color-grey-50;
 	overflow: auto;
 }
 
@@ -17,7 +30,7 @@
 	@include flex(1 1 250px);
 	width: 250px;
 	float: left;
-	padding: 2em $site-margins/2;
+	padding: 0 $site-margins/2 2em $site-margins/2;
 	border-right: 1px solid $color-grey-300;
 	overflow: auto;
 	&:last-child {
@@ -98,7 +111,7 @@
 	background-color: #fff;
 	box-shadow: $box-shadow-1;
 	padding: $site-margins/4 $site-margins/2;
-	margin: 1em 0;
+	margin: .2em 0 1em 0;
 }
 
 .activity--edited {
@@ -130,13 +143,14 @@
 .activity__author {
 	margin: 0;
 	font-size: $base-font-size;
+	color: $color-grey-700;
 }
 
 .activity__actions {
 	margin-top: .5em;
 	border-top: 1px solid $color-grey-300;
 	padding-top: .5em;
-	a {
+	.toolbar__item {
 		color: $color-grey-400;
 		&:hover {
 			color: $color-grey-600;

--- a/chime/static/sass/templates/_activities-list.scss
+++ b/chime/static/sass/templates/_activities-list.scss
@@ -150,11 +150,24 @@
 	}
 }
 
-.activity__author {
+.activity__status {
 	margin: 0;
 	font-size: $base-font-size;
 	color: $color-grey-500;
 	font-weight: 400;
+	width: 100%;
+	
+}
+
+.activity__author {
+	white-space: pre;           /* CSS 2.0 */
+	white-space: pre-wrap;      /* CSS 2.1 */
+	white-space: pre-line;      /* CSS 3.0 */
+	white-space: -pre-wrap;     /* Opera 4-6 */
+	white-space: -o-pre-wrap;   /* Opera 7 */
+	white-space: -moz-pre-wrap; /* Mozilla */
+	white-space: -hp-pre-wrap;  /* HP Printers */
+	word-wrap: break-word;      /* IE 5+ */
 }
 
 .activity__actions {

--- a/chime/static/sass/templates/_activity-overview.scss
+++ b/chime/static/sass/templates/_activity-overview.scss
@@ -23,13 +23,10 @@
 	margin: 3em auto;
 	max-width: 680px;
 	box-shadow: $box-shadow-1;
+	background-color: #fff;
 	.row {
 		padding: 2em $site-margins;
 		border-top: 1px solid $color-grey-200;
-		background-color: #fff;
-		&:first-child {
-			border-top: 0;
-		}
 	}
 }
 
@@ -44,7 +41,7 @@
 .activity-overview__description {
 	font-size: $text-font-size;
 	font-weight: 600;
-	padding-bottom: 2em;
+	margin-top: 0;
 	a {
 		color: inherit;
 		text-decoration: underline;

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -1207,44 +1207,113 @@ input[type="submit"]:disabled:hover {
 .button--text {
   background-color: transparent;
   border: 1px solid transparent;
-  border-radius: 0;
 }
-/* line 118, ../sass/components/_buttons.scss */
+/* line 117, ../sass/components/_buttons.scss */
 .button--text:hover, .button--text:active, .button--text.is-selected {
-  background-color: transparent;
-  border-color: transparent;
-  border-bottom: 1px solid #000;
+  background-color: #e0e0e0;
+  border-color: #e0e0e0;
   color: #000;
 }
 
-/* line 126, ../sass/components/_buttons.scss */
+/* line 124, ../sass/components/_buttons.scss */
 .button--medium {
   font-size: 14px;
   padding: .5em 1em;
   font-weight: 400;
 }
-/* line 130, ../sass/components/_buttons.scss */
+/* line 128, ../sass/components/_buttons.scss */
 .button--medium.is-loading {
   padding-right: 1em;
 }
-/* line 132, ../sass/components/_buttons.scss */
+/* line 130, ../sass/components/_buttons.scss */
 .button--medium.is-loading:after {
   margin-top: 0;
 }
 
-/* line 138, ../sass/components/_buttons.scss */
+/* line 136, ../sass/components/_buttons.scss */
 .button--large {
   font-size: 18px;
   padding: .5em 1em;
   font-weight: 400;
 }
-/* line 142, ../sass/components/_buttons.scss */
+/* line 140, ../sass/components/_buttons.scss */
 .button--large.is-loading {
   padding-right: 1em;
 }
-/* line 144, ../sass/components/_buttons.scss */
+/* line 142, ../sass/components/_buttons.scss */
 .button--large.is-loading:after {
   margin-top: 0;
+}
+
+/* line 1, ../sass/components/_modal.scss */
+.modal-container {
+  -webkit-transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
+  -moz-transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
+  transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
+  display: -webkit-box;
+  display: -moz-box;
+  display: box;
+  display: -webkit-flex;
+  display: -moz-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -moz-box-pack: center;
+  box-pack: center;
+  -webkit-justify-content: center;
+  -moz-justify-content: center;
+  -ms-justify-content: center;
+  -o-justify-content: center;
+  justify-content: center;
+  -ms-flex-pack: center;
+  -webkit-box-align: center;
+  -moz-box-align: center;
+  box-align: center;
+  -webkit-align-items: center;
+  -moz-align-items: center;
+  -ms-align-items: center;
+  -o-align-items: center;
+  align-items: center;
+  -ms-flex-align: center;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #424242;
+  background-color: rgba(0, 0, 0, 0.15);
+  z-index: -2;
+  opacity: 0;
+  margin-top: -2em;
+}
+/* line 16, ../sass/components/_modal.scss */
+.modal-container.is-open {
+  margin-top: 0;
+  z-index: 9999;
+  opacity: 1;
+}
+
+/* line 22, ../sass/components/_modal.scss */
+.modal {
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  width: 600px;
+  margin: 0 auto;
+  height: auto;
+  padding: 20px;
+}
+/* line 7, ../sass/core/_utilities.scss */
+.modal:before, .modal:after {
+  content: " ";
+  display: table;
+}
+/* line 11, ../sass/core/_utilities.scss */
+.modal:after {
+  clear: both;
+}
+/* line 30, ../sass/components/_modal.scss */
+.lt-ie10 .modal {
+  margin-top: 4em;
 }
 
 /* line 1, ../sass/components/_alerts.scss */
@@ -1957,11 +2026,17 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 1, ../sass/templates/_activities-list.scss */
+.activities-list__header {
+  background-color: #fff;
+  border-bottom: 1px solid #e0e0e0;
+}
+/* line 4, ../sass/templates/_activities-list.scss */
+.activities-list__header p {
+  margin: .4em 0 0 0;
+}
+
+/* line 9, ../sass/templates/_activities-list.scss */
 .activities-list__main {
-  padding-top: 1em;
-  padding-bottom: 1em;
-  padding-left: 40px;
-  padding-right: 40px;
   display: -webkit-box;
   display: -moz-box;
   display: box;
@@ -1978,6 +2053,7 @@ input[type="submit"]:disabled:hover {
   -o-align-items: stretch;
   align-items: stretch;
   -ms-flex-align: stretch;
+  padding: 0 20px;
   background-color: #fafafa;
   overflow: auto;
 }
@@ -1986,108 +2062,156 @@ input[type="submit"]:disabled:hover {
   display: block;
 }
 
-/* line 8, ../sass/templates/_activities-list.scss */
-.current-tasks__empty-description {
-  font-size: 28px;
-  font-weight: 300;
-  max-width: 500px;
-  margin-top: 4em;
+/* line 16, ../sass/templates/_activities-list.scss */
+.activity-box {
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  -webkit-flex: 1 1 250px;
+  -moz-flex: 1 1 250px;
+  -ms-flex: 1 1 250px;
+  flex: 1 1 250px;
+  width: 250px;
+  float: left;
+  padding: 2em 20px;
+  border-right: 1px solid #e0e0e0;
+  overflow: auto;
+}
+/* line 23, ../sass/templates/_activities-list.scss */
+.activity-box:last-child {
+  border-right: 0;
 }
 
-/* line 15, ../sass/templates/_activities-list.scss */
-.current-tasks__list {
-  margin: 2em 0;
-  margin-right: 20px;
+/* line 28, ../sass/templates/_activities-list.scss */
+.new-activity {
+  width: 480px;
 }
-
-/* line 20, ../sass/templates/_activities-list.scss */
-.current-task {
-  -webkit-transition: box-shadow ease-out 0.2s;
-  -moz-transition: box-shadow ease-out 0.2s;
-  transition: box-shadow ease-out 0.2s;
-  display: block;
-  padding: .5em 1em;
-  background-color: #fff;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
-  margin-bottom: 2em;
-}
-/* line 27, ../sass/templates/_activities-list.scss */
-.lt-ie10 .current-task {
-  border: 1px solid #eeeeee;
-}
-
-/* line 32, ../sass/templates/_activities-list.scss */
-.current-task__title {
-  font-size: 28px;
-  border-bottom: 1px solid #f5f5f5;
-  margin-top: .5em;
-  margin-bottom: .5em;
-  padding-bottom: .5em;
-}
-/* line 38, ../sass/templates/_activities-list.scss */
-.current-task__title a {
-  color: #212121;
-  display: block;
-  position: relative;
-}
-/* line 42, ../sass/templates/_activities-list.scss */
-.current-task__title a:after {
-  content: '\f105';
-  font-family: "FontAwesome";
-  position: absolute;
-  display: block;
-  right: 0;
-  top: 0;
-}
-/* line 50, ../sass/templates/_activities-list.scss */
-.current-task__title a:hover {
-  color: #2b93d1;
-  text-decoration: none;
-}
-
-/* line 57, ../sass/templates/_activities-list.scss */
-.current-task__author {
+/* line 30, ../sass/templates/_activities-list.scss */
+.new-activity h3 {
   margin-top: 0;
 }
-
-/* line 61, ../sass/templates/_activities-list.scss */
-.current-task__details {
-  padding: 0;
-}
-
-/* line 65, ../sass/templates/_activities-list.scss */
-.new-task {
-  padding: 0 20px;
-  border-left: 1px solid #eeeeee;
-}
-/* line 68, ../sass/templates/_activities-list.scss */
-.new-task input {
-  margin: .5em 0;
-}
-
-/* line 73, ../sass/templates/_activities-list.scss */
-.new-task__description {
-  margin-top: 0;
-  font-weight: bold;
-}
-
-/* line 78, ../sass/templates/_activities-list.scss */
-.new-task__form {
-  margin-top: 5em;
-  background-color: #f5f5f5;
-  border: 1px solid #e0e0e0;
-  padding: 1em;
-}
-
-/* line 85, ../sass/templates/_activities-list.scss */
-.new-task__textarea {
+/* line 33, ../sass/templates/_activities-list.scss */
+.new-activity textarea {
+  font-size: 18px;
   resize: none;
   padding: .5em;
 }
+/* line 39, ../sass/templates/_activities-list.scss */
+.new-activity .grid button[type="submit"] {
+  margin-top: 1.4em;
+}
+/* line 42, ../sass/templates/_activities-list.scss */
+.new-activity .grid p {
+  padding-left: 2em;
+}
+
+/* line 49, ../sass/templates/_activities-list.scss */
+.activity-box__title {
+  font-size: 18px;
+  font-weight: 400;
+  margin-top: 0;
+  margin-bottom: 2em;
+  position: relative;
+}
+/* line 55, ../sass/templates/_activities-list.scss */
+.activity-box__title:before {
+  display: inline-block;
+  margin-right: .5em;
+  font-family: "FontAwesome";
+}
+
+/* line 63, ../sass/templates/_activities-list.scss */
+.activity-box__title--edited:before {
+  content: '\f040';
+}
+
+/* line 69, ../sass/templates/_activities-list.scss */
+.activity-box__title--feedback:before {
+  content: '\f087';
+}
+
+/* line 75, ../sass/templates/_activities-list.scss */
+.activity-box__title--endorsed:before {
+  content: '\f040';
+}
+
+/* line 81, ../sass/templates/_activities-list.scss */
+.activity-box__title--published:before {
+  content: '\f00c';
+}
+
+/* line 86, ../sass/templates/_activities-list.scss */
+.activity-box__list {
+  margin-top: 0;
+}
 
 /* line 90, ../sass/templates/_activities-list.scss */
-.new-task__actions {
-  margin-top: 1em;
+.activity-box__empty-state {
+  font-size: 18px;
+  text-align: center;
+  color: #757575;
+}
+
+/* line 96, ../sass/templates/_activities-list.scss */
+.activity {
+  padding: 1em 0;
+  background-color: #fff;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
+  padding: 10px 20px;
+  margin: 1em 0;
+}
+
+/* line 104, ../sass/templates/_activities-list.scss */
+.activity--edited {
+  border-left: 4px solid #e0e0e0;
+}
+
+/* line 108, ../sass/templates/_activities-list.scss */
+.activity--feedback {
+  border-left: 4px solid #f1b17f;
+}
+
+/* line 112, ../sass/templates/_activities-list.scss */
+.activity--endorsed {
+  border-left: 4px solid #66c6ac;
+}
+
+/* line 116, ../sass/templates/_activities-list.scss */
+.activity--published {
+  border-left: 4px solid #6693a5;
+}
+
+/* line 120, ../sass/templates/_activities-list.scss */
+.activity__title {
+  font-weight: 400;
+  font-size: 18px;
+  margin: 0;
+  margin-bottom: .2em;
+}
+/* line 125, ../sass/templates/_activities-list.scss */
+.activity__title a {
+  color: #000;
+}
+
+/* line 130, ../sass/templates/_activities-list.scss */
+.activity__author {
+  margin: 0;
+  font-size: 14px;
+}
+
+/* line 135, ../sass/templates/_activities-list.scss */
+.activity__actions {
+  margin-top: .5em;
+  border-top: 1px solid #e0e0e0;
+  padding-top: .5em;
+}
+/* line 139, ../sass/templates/_activities-list.scss */
+.activity__actions a {
+  color: #bdbdbd;
+}
+/* line 141, ../sass/templates/_activities-list.scss */
+.activity__actions a:hover {
+  color: #757575;
 }
 
 /* line 1, ../sass/templates/_activity-overview.scss */

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -449,22 +449,22 @@ th {
   padding: 0;
 }
 
-/* line 42, ../sass/core/_utilities.scss */
+/* line 41, ../sass/core/_utilities.scss */
 .is-hidden {
   display: none !important;
 }
 
-/* line 46, ../sass/core/_utilities.scss */
+/* line 45, ../sass/core/_utilities.scss */
 .text-red {
   color: #aa1c3a !important;
 }
 
-/* line 50, ../sass/core/_utilities.scss */
+/* line 49, ../sass/core/_utilities.scss */
 .text-green {
   color: #00a175 !important;
 }
 
-/* line 54, ../sass/core/_utilities.scss */
+/* line 53, ../sass/core/_utilities.scss */
 .text-detail {
   font-size: 14px;
   font-weight: 400;
@@ -1493,7 +1493,6 @@ input[type="submit"]:disabled:hover {
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-bottom: 7.5px solid #e0e0e0;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
@@ -1923,7 +1922,6 @@ input[type="submit"]:disabled:hover {
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-left: 9px solid #e0e0e0;
   border-bottom: 6px solid transparent;
   border-top: 6px solid transparent;
@@ -1941,7 +1939,6 @@ input[type="submit"]:disabled:hover {
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-left: 9px solid #757575;
   border-bottom: 6px solid transparent;
   border-top: 6px solid transparent;
@@ -2187,7 +2184,6 @@ input[type="submit"]:disabled:hover {
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-bottom: 6px solid #212121;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
@@ -2268,7 +2264,6 @@ input[type="submit"]:disabled:hover {
   width: 0;
   height: 0;
   content: '';
-  z-index: 2;
   border-left: 9px solid #e0e0e0;
   border-bottom: 6px solid transparent;
   border-top: 6px solid transparent;
@@ -2390,12 +2385,16 @@ input[type="submit"]:disabled:hover {
 
 /* line 109, ../sass/templates/_activities-list.scss */
 .activity-box__empty-state {
-  font-size: 18px;
-  text-align: center;
-  color: #757575;
+  height: 6em;
+  width: 6em;
+  text-indent: -9999px;
+  margin: 3em auto;
+  opacity: .3;
+  background: url("../images/chime_symbol.svg") no-repeat center center;
+  background-size: 6em 6em;
 }
 
-/* line 115, ../sass/templates/_activities-list.scss */
+/* line 119, ../sass/templates/_activities-list.scss */
 .activity {
   padding: 1em 0;
   background-color: #fff;
@@ -2404,39 +2403,39 @@ input[type="submit"]:disabled:hover {
   margin: .2em 0 1em 0;
 }
 
-/* line 123, ../sass/templates/_activities-list.scss */
+/* line 127, ../sass/templates/_activities-list.scss */
 .activity--edited {
   border-left: 4px solid #757575;
 }
 
-/* line 127, ../sass/templates/_activities-list.scss */
+/* line 131, ../sass/templates/_activities-list.scss */
 .activity--feedback {
   border-left: 4px solid #f1b17f;
 }
 
-/* line 131, ../sass/templates/_activities-list.scss */
+/* line 135, ../sass/templates/_activities-list.scss */
 .activity--endorsed {
   border-left: 4px solid #66c6ac;
 }
 
-/* line 135, ../sass/templates/_activities-list.scss */
+/* line 139, ../sass/templates/_activities-list.scss */
 .activity--published {
   border-left: 4px solid #6693a5;
 }
 
-/* line 139, ../sass/templates/_activities-list.scss */
+/* line 143, ../sass/templates/_activities-list.scss */
 .activity__title {
   font-weight: 400;
   font-size: 18px;
   margin: 0;
   margin-bottom: .2em;
 }
-/* line 144, ../sass/templates/_activities-list.scss */
+/* line 148, ../sass/templates/_activities-list.scss */
 .activity__title a {
   color: #000;
 }
 
-/* line 149, ../sass/templates/_activities-list.scss */
+/* line 153, ../sass/templates/_activities-list.scss */
 .activity__author {
   margin: 0;
   font-size: 14px;
@@ -2444,7 +2443,7 @@ input[type="submit"]:disabled:hover {
   font-weight: 400;
 }
 
-/* line 156, ../sass/templates/_activities-list.scss */
+/* line 160, ../sass/templates/_activities-list.scss */
 .activity__actions {
   width: auto;
   margin-top: .5em;
@@ -2455,11 +2454,11 @@ input[type="submit"]:disabled:hover {
   border-top: 1px solid #eeeeee;
   padding-top: .5em;
 }
-/* line 169, ../sass/templates/_activities-list.scss */
+/* line 173, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item {
   color: #bdbdbd;
 }
-/* line 171, ../sass/templates/_activities-list.scss */
+/* line 175, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item:hover {
   color: #757575;
 }

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -1616,30 +1616,29 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 1, ../sass/components/_activity-progress.scss */
-.activity-progress {
+.activity-overview__main .activity-progress.row {
   font-size: 18px;
   margin: 0;
   margin-top: -1px;
-  padding-bottom: 1.5em;
   padding-right: 0;
   padding-left: 0;
 }
 /* line 7, ../sass/core/_utilities.scss */
-.activity-progress:before, .activity-progress:after {
+.activity-overview__main .activity-progress.row:before, .activity-overview__main .activity-progress.row:after {
   content: " ";
   display: table;
 }
 /* line 11, ../sass/core/_utilities.scss */
-.activity-progress:after {
+.activity-overview__main .activity-progress.row:after {
   clear: both;
 }
 
-/* line 13, ../sass/components/_activity-progress.scss */
+/* line 12, ../sass/components/_activity-progress.scss */
 .activity-progress__item {
   text-align: center;
   position: relative;
 }
-/* line 16, ../sass/components/_activity-progress.scss */
+/* line 15, ../sass/components/_activity-progress.scss */
 .activity-progress__item:before {
   content: '';
   display: block;
@@ -1647,50 +1646,90 @@ input[type="submit"]:disabled:hover {
   top: 1em;
   left: -50%;
   right: 50%;
-  height: 4px;
+  margin-right: 1.4em;
+  margin-left: 1.4em;
+  height: 2px;
   margin-top: -2px;
   background-color: #eeeeee;
   z-index: 0;
 }
-/* line 29, ../sass/components/_activity-progress.scss */
+/* line 30, ../sass/components/_activity-progress.scss */
 .activity-progress__item:first-child:before {
   display: none;
 }
-/* line 34, ../sass/components/_activity-progress.scss */
+/* line 35, ../sass/components/_activity-progress.scss */
 .activity-progress__item.is-completed:before {
-  background-color: #66c6ac;
+  background-color: #757575;
+}
+/* line 41, ../sass/components/_activity-progress.scss */
+.activity-progress__item--edited.is-completed .activity-progress__icon {
+  border-color: #616161;
+  color: #616161;
+}
+/* line 49, ../sass/components/_activity-progress.scss */
+.activity-progress__item--requested.is-completed .activity-progress__icon {
+  border-color: #f1b17f;
+  color: #f1b17f;
+}
+/* line 57, ../sass/components/_activity-progress.scss */
+.activity-progress__item--endorsed.is-completed .activity-progress__icon {
+  border-color: #66c6ac;
+  color: #66c6ac;
+}
+/* line 65, ../sass/components/_activity-progress.scss */
+.activity-progress__item--published.is-completed .activity-progress__icon {
+  border-color: #6693a5;
+  color: #6693a5;
 }
 
-/* line 40, ../sass/components/_activity-progress.scss */
+/* line 73, ../sass/components/_activity-progress.scss */
 .activity-progress__label {
   font-size: 14px;
   color: #9e9e9e;
   font-weight: 300;
   margin-bottom: 0;
 }
-/* line 45, ../sass/components/_activity-progress.scss */
+/* line 78, ../sass/components/_activity-progress.scss */
 .is-completed .activity-progress__label {
   color: #000;
   font-weight: 600;
 }
 
-/* line 51, ../sass/components/_activity-progress.scss */
+/* line 84, ../sass/components/_activity-progress.scss */
 .activity-progress__icon {
+  display: inline-block;
   position: relative;
   z-index: 1;
-  padding: .5em;
   border-radius: 50%;
   height: 2em;
   width: 2em;
   text-align: center;
-  line-height: 1em;
-  background-color: #eeeeee;
+  line-height: 2em;
+  border: 2px solid #e0e0e0;
   color: #9e9e9e;
 }
-/* line 62, ../sass/components/_activity-progress.scss */
-.is-completed .activity-progress__icon {
-  background-color: #33b390;
-  color: #fff;
+/* line 95, ../sass/components/_activity-progress.scss */
+.activity-progress__icon:before {
+  font-family: "FontAwesome";
+  position: relative;
+  top: -1px;
+}
+/* line 101, ../sass/components/_activity-progress.scss */
+.activity-progress__item--edited .activity-progress__icon:before {
+  content: '\f040';
+}
+/* line 106, ../sass/components/_activity-progress.scss */
+.activity-progress__item--requested .activity-progress__icon:before {
+  top: -2px;
+  content: '\f06e';
+}
+/* line 112, ../sass/components/_activity-progress.scss */
+.activity-progress__item--endorsed .activity-progress__icon:before {
+  content: '\f087';
+}
+/* line 117, ../sass/components/_activity-progress.scss */
+.activity-progress__item--published .activity-progress__icon:before {
+  content: '\f00c';
 }
 
 /* line 1, ../sass/components/_activity-summary.scss */
@@ -2082,31 +2121,27 @@ input[type="submit"]:disabled:hover {
   margin: 3em auto;
   max-width: 680px;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
+  background-color: #fff;
 }
-/* line 26, ../sass/templates/_activity-overview.scss */
+/* line 27, ../sass/templates/_activity-overview.scss */
 .activity-overview__main .row {
   padding: 2em 40px;
   border-top: 1px solid #eeeeee;
-  background-color: #fff;
-}
-/* line 30, ../sass/templates/_activity-overview.scss */
-.activity-overview__main .row:first-child {
-  border-top: 0;
 }
 
-/* line 38, ../sass/templates/_activity-overview.scss */
+/* line 35, ../sass/templates/_activity-overview.scss */
 .activity-overview .activity-log.row {
   background-color: #fafafa;
   margin-top: -1px;
 }
 
-/* line 44, ../sass/templates/_activity-overview.scss */
+/* line 41, ../sass/templates/_activity-overview.scss */
 .activity-overview__description {
   font-size: 16px;
   font-weight: 600;
-  padding-bottom: 2em;
+  margin-top: 0;
 }
-/* line 48, ../sass/templates/_activity-overview.scss */
+/* line 45, ../sass/templates/_activity-overview.scss */
 .activity-overview__description a {
   color: inherit;
   text-decoration: underline;

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -1812,7 +1812,7 @@ input[type="submit"]:disabled:hover {
   content: '';
   display: block;
   position: absolute;
-  top: 1.25em;
+  top: 1.3em;
   left: -50%;
   right: 50%;
   margin-right: 2em;
@@ -1822,50 +1822,66 @@ input[type="submit"]:disabled:hover {
   background-color: #eeeeee;
   z-index: 0;
 }
-/* line 29, ../sass/components/_activity-progress.scss */
-.activity-progress__item:first-child:before {
+/* line 28, ../sass/components/_activity-progress.scss */
+.activity-progress__item:after {
+  position: absolute;
+  display: block;
+  top: 1.3em;
+  margin-top: -7px;
+  right: 50%;
+  margin-right: 1.8em;
+  width: 0;
+  height: 0;
+  content: '';
+  z-index: 2;
+  border-left: 9px solid #e0e0e0;
+  border-bottom: 6px solid transparent;
+  border-top: 6px solid transparent;
+}
+/* line 38, ../sass/components/_activity-progress.scss */
+.activity-progress__item:first-child:before, .activity-progress__item:first-child:after {
   display: none;
 }
-/* line 34, ../sass/components/_activity-progress.scss */
+/* line 43, ../sass/components/_activity-progress.scss */
 .activity-progress__item.is-completed:before {
   background-color: #757575;
 }
-/* line 40, ../sass/components/_activity-progress.scss */
+/* line 49, ../sass/components/_activity-progress.scss */
 .activity-progress__item--edited.is-completed .activity-progress__icon {
   border-color: #616161;
   color: #616161;
 }
-/* line 48, ../sass/components/_activity-progress.scss */
+/* line 57, ../sass/components/_activity-progress.scss */
 .activity-progress__item--requested.is-completed .activity-progress__icon {
   border-color: #f1b17f;
   color: #f1b17f;
 }
-/* line 56, ../sass/components/_activity-progress.scss */
+/* line 65, ../sass/components/_activity-progress.scss */
 .activity-progress__item--endorsed.is-completed .activity-progress__icon {
   border-color: #66c6ac;
   color: #66c6ac;
 }
-/* line 64, ../sass/components/_activity-progress.scss */
+/* line 73, ../sass/components/_activity-progress.scss */
 .activity-progress__item--published.is-completed .activity-progress__icon {
   border-color: #6693a5;
   color: #6693a5;
 }
 
-/* line 72, ../sass/components/_activity-progress.scss */
+/* line 81, ../sass/components/_activity-progress.scss */
 .activity-progress__label {
-  font-size: 18px;
+  font-size: 16px;
   color: #9e9e9e;
   font-weight: 300;
   margin-top: .5em;
   margin-bottom: 0;
 }
-/* line 78, ../sass/components/_activity-progress.scss */
+/* line 87, ../sass/components/_activity-progress.scss */
 .is-completed .activity-progress__label {
   color: #000;
   font-weight: 400;
 }
 
-/* line 84, ../sass/components/_activity-progress.scss */
+/* line 93, ../sass/components/_activity-progress.scss */
 .activity-progress__icon {
   display: inline-block;
   position: relative;
@@ -1878,26 +1894,26 @@ input[type="submit"]:disabled:hover {
   border: 2px solid #e0e0e0;
   color: #9e9e9e;
 }
-/* line 95, ../sass/components/_activity-progress.scss */
+/* line 104, ../sass/components/_activity-progress.scss */
 .activity-progress__icon:before {
   font-family: "FontAwesome";
   position: relative;
   top: -1px;
 }
-/* line 101, ../sass/components/_activity-progress.scss */
+/* line 110, ../sass/components/_activity-progress.scss */
 .activity-progress__item--edited .activity-progress__icon:before {
   content: '\f040';
 }
-/* line 106, ../sass/components/_activity-progress.scss */
+/* line 115, ../sass/components/_activity-progress.scss */
 .activity-progress__item--requested .activity-progress__icon:before {
   top: -2px;
   content: '\f06e';
 }
-/* line 112, ../sass/components/_activity-progress.scss */
+/* line 121, ../sass/components/_activity-progress.scss */
 .activity-progress__item--endorsed .activity-progress__icon:before {
   content: '\f087';
 }
-/* line 117, ../sass/components/_activity-progress.scss */
+/* line 126, ../sass/components/_activity-progress.scss */
 .activity-progress__item--published .activity-progress__icon:before {
   content: '\f00c';
 }
@@ -2192,7 +2208,7 @@ input[type="submit"]:disabled:hover {
   width: 250px;
   float: left;
   padding: 0 20px 2em 20px;
-  border-right: 1px solid #e0e0e0;
+  border-right: 1px solid #eeeeee;
   overflow: auto;
 }
 /* line 36, ../sass/templates/_activities-list.scss */
@@ -2275,13 +2291,13 @@ input[type="submit"]:disabled:hover {
   padding: 1em 0;
   background-color: #fff;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
-  padding: 10px 20px;
+  padding: 10px;
   margin: .2em 0 1em 0;
 }
 
 /* line 117, ../sass/templates/_activities-list.scss */
 .activity--edited {
-  border-left: 4px solid #e0e0e0;
+  border-left: 4px solid #757575;
 }
 
 /* line 121, ../sass/templates/_activities-list.scss */
@@ -2315,20 +2331,26 @@ input[type="submit"]:disabled:hover {
 .activity__author {
   margin: 0;
   font-size: 14px;
-  color: #616161;
+  color: #9e9e9e;
+  font-weight: 400;
 }
 
-/* line 149, ../sass/templates/_activities-list.scss */
+/* line 150, ../sass/templates/_activities-list.scss */
 .activity__actions {
+  width: auto;
   margin-top: .5em;
-  border-top: 1px solid #e0e0e0;
+  margin-left: -10px;
+  margin-right: -10px;
+  padding-left: 10px;
+  padding-right: 10px;
+  border-top: 1px solid #eeeeee;
   padding-top: .5em;
 }
-/* line 153, ../sass/templates/_activities-list.scss */
+/* line 163, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item {
   color: #bdbdbd;
 }
-/* line 155, ../sass/templates/_activities-list.scss */
+/* line 165, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item:hover {
   color: #757575;
 }

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -789,6 +789,48 @@ a:hover {
     transform: rotate(359deg);
   }
 }
+@-webkit-keyframes tooltip {
+  0% {
+    display: none;
+    opacity: 0;
+    top: 110%;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    top: 100%;
+  }
+}
+@-moz-keyframes tooltip {
+  0% {
+    display: none;
+    opacity: 0;
+    top: 110%;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    top: 100%;
+  }
+}
+@keyframes tooltip {
+  0% {
+    display: none;
+    opacity: 0;
+    top: 110%;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    top: 100%;
+  }
+}
 /*------------------------------------*\
     # Components
 \*------------------------------------*/
@@ -1216,31 +1258,39 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 124, ../sass/components/_buttons.scss */
+.button--nostyle {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+}
+
+/* line 131, ../sass/components/_buttons.scss */
 .button--medium {
   font-size: 14px;
   padding: .5em 1em;
   font-weight: 400;
 }
-/* line 128, ../sass/components/_buttons.scss */
+/* line 135, ../sass/components/_buttons.scss */
 .button--medium.is-loading {
   padding-right: 1em;
 }
-/* line 130, ../sass/components/_buttons.scss */
+/* line 137, ../sass/components/_buttons.scss */
 .button--medium.is-loading:after {
   margin-top: 0;
 }
 
-/* line 136, ../sass/components/_buttons.scss */
+/* line 143, ../sass/components/_buttons.scss */
 .button--large {
   font-size: 18px;
   padding: .5em 1em;
   font-weight: 400;
 }
-/* line 140, ../sass/components/_buttons.scss */
+/* line 147, ../sass/components/_buttons.scss */
 .button--large.is-loading {
   padding-right: 1em;
 }
-/* line 142, ../sass/components/_buttons.scss */
+/* line 149, ../sass/components/_buttons.scss */
 .button--large.is-loading:after {
   margin-top: 0;
 }
@@ -1314,6 +1364,57 @@ input[type="submit"]:disabled:hover {
 /* line 30, ../sass/components/_modal.scss */
 .lt-ie10 .modal {
   margin-top: 4em;
+}
+
+/* line 1, ../sass/components/_tooltip.scss */
+.tooltipped {
+  position: relative;
+}
+/* line 4, ../sass/components/_tooltip.scss */
+.tooltipped:hover .tooltipped__tt-container {
+  -webkit-animation: tooltip 0.2s ease-out;
+  -moz-animation: tooltip 0.2s ease-out;
+  animation: tooltip 0.2s ease-out;
+  display: block;
+  top: 100%;
+  opacity: 1;
+}
+
+/* line 13, ../sass/components/_tooltip.scss */
+.tooltipped__tt-container {
+  display: none;
+  position: absolute;
+  left: 50%;
+  top: 120%;
+  margin-top: 6px;
+}
+
+/* line 21, ../sass/components/_tooltip.scss */
+.tooltipped__tt {
+  position: relative;
+  left: -50%;
+  background-color: #eeeeee;
+  border: 1px solid #e0e0e0;
+  color: #000;
+  line-height: 2em;
+  padding: .3em .7em;
+  text-align: center;
+  font-weight: 400;
+  font-size: 12px;
+}
+/* line 33, ../sass/components/_tooltip.scss */
+.tooltipped__tt:before {
+  position: absolute;
+  left: 50%;
+  margin-left: -5px;
+  top: -8px;
+  width: 0;
+  height: 0;
+  content: '';
+  z-index: 2;
+  border-bottom: 7.5px solid #e0e0e0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
 }
 
 /* line 1, ../sass/components/_alerts.scss */
@@ -1686,7 +1787,6 @@ input[type="submit"]:disabled:hover {
 
 /* line 1, ../sass/components/_activity-progress.scss */
 .activity-overview__main .activity-progress.row {
-  font-size: 18px;
   margin: 0;
   margin-top: -1px;
   padding-right: 0;
@@ -1702,66 +1802,67 @@ input[type="submit"]:disabled:hover {
   clear: both;
 }
 
-/* line 12, ../sass/components/_activity-progress.scss */
+/* line 11, ../sass/components/_activity-progress.scss */
 .activity-progress__item {
   text-align: center;
   position: relative;
 }
-/* line 15, ../sass/components/_activity-progress.scss */
+/* line 14, ../sass/components/_activity-progress.scss */
 .activity-progress__item:before {
   content: '';
   display: block;
   position: absolute;
-  top: 1em;
+  top: 1.25em;
   left: -50%;
   right: 50%;
-  margin-right: 1.4em;
-  margin-left: 1.4em;
+  margin-right: 2em;
+  margin-left: 2em;
   height: 2px;
   margin-top: -2px;
   background-color: #eeeeee;
   z-index: 0;
 }
-/* line 30, ../sass/components/_activity-progress.scss */
+/* line 29, ../sass/components/_activity-progress.scss */
 .activity-progress__item:first-child:before {
   display: none;
 }
-/* line 35, ../sass/components/_activity-progress.scss */
+/* line 34, ../sass/components/_activity-progress.scss */
 .activity-progress__item.is-completed:before {
   background-color: #757575;
 }
-/* line 41, ../sass/components/_activity-progress.scss */
+/* line 40, ../sass/components/_activity-progress.scss */
 .activity-progress__item--edited.is-completed .activity-progress__icon {
   border-color: #616161;
   color: #616161;
 }
-/* line 49, ../sass/components/_activity-progress.scss */
+/* line 48, ../sass/components/_activity-progress.scss */
 .activity-progress__item--requested.is-completed .activity-progress__icon {
   border-color: #f1b17f;
   color: #f1b17f;
 }
-/* line 57, ../sass/components/_activity-progress.scss */
+/* line 56, ../sass/components/_activity-progress.scss */
 .activity-progress__item--endorsed.is-completed .activity-progress__icon {
   border-color: #66c6ac;
   color: #66c6ac;
 }
-/* line 65, ../sass/components/_activity-progress.scss */
+/* line 64, ../sass/components/_activity-progress.scss */
 .activity-progress__item--published.is-completed .activity-progress__icon {
   border-color: #6693a5;
   color: #6693a5;
 }
 
-/* line 73, ../sass/components/_activity-progress.scss */
+/* line 72, ../sass/components/_activity-progress.scss */
 .activity-progress__label {
-  font-size: 14px;
+  font-size: 18px;
   color: #9e9e9e;
   font-weight: 300;
+  margin-top: .5em;
   margin-bottom: 0;
 }
 /* line 78, ../sass/components/_activity-progress.scss */
 .is-completed .activity-progress__label {
   color: #000;
-  font-weight: 600;
+  font-weight: 400;
 }
 
 /* line 84, ../sass/components/_activity-progress.scss */
@@ -1770,10 +1871,10 @@ input[type="submit"]:disabled:hover {
   position: relative;
   z-index: 1;
   border-radius: 50%;
-  height: 2em;
-  width: 2em;
+  height: 2.5em;
+  width: 2.5em;
   text-align: center;
-  line-height: 2em;
+  line-height: 2.5em;
   border: 2px solid #e0e0e0;
   color: #9e9e9e;
 }
@@ -2026,16 +2127,34 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 1, ../sass/templates/_activities-list.scss */
+.activities-list {
+  background-color: #fafafa;
+}
+
+/* line 5, ../sass/templates/_activities-list.scss */
 .activities-list__header {
   background-color: #fff;
   border-bottom: 1px solid #e0e0e0;
 }
-/* line 4, ../sass/templates/_activities-list.scss */
+/* line 8, ../sass/templates/_activities-list.scss */
 .activities-list__header p {
   margin: .4em 0 0 0;
 }
 
-/* line 9, ../sass/templates/_activities-list.scss */
+/* line 13, ../sass/templates/_activities-list.scss */
+.activity-list__states {
+  padding: 1em 0;
+}
+/* line 15, ../sass/templates/_activities-list.scss */
+.activity-list__states .activity-progress__item:before {
+  background-color: #e0e0e0;
+}
+/* line 18, ../sass/templates/_activities-list.scss */
+.activity-list__states .activity-progress__label {
+  font-weight: 300;
+}
+
+/* line 23, ../sass/templates/_activities-list.scss */
 .activities-list__main {
   display: -webkit-box;
   display: -moz-box;
@@ -2054,7 +2173,6 @@ input[type="submit"]:disabled:hover {
   align-items: stretch;
   -ms-flex-align: stretch;
   padding: 0 20px;
-  background-color: #fafafa;
   overflow: auto;
 }
 /* line 6, ../sass/core/_layout.scss */
@@ -2062,7 +2180,7 @@ input[type="submit"]:disabled:hover {
   display: block;
 }
 
-/* line 16, ../sass/templates/_activities-list.scss */
+/* line 29, ../sass/templates/_activities-list.scss */
 .activity-box {
   -webkit-box-flex: 1;
   -moz-box-flex: 1;
@@ -2073,39 +2191,39 @@ input[type="submit"]:disabled:hover {
   flex: 1 1 250px;
   width: 250px;
   float: left;
-  padding: 2em 20px;
+  padding: 0 20px 2em 20px;
   border-right: 1px solid #e0e0e0;
   overflow: auto;
 }
-/* line 23, ../sass/templates/_activities-list.scss */
+/* line 36, ../sass/templates/_activities-list.scss */
 .activity-box:last-child {
   border-right: 0;
 }
 
-/* line 28, ../sass/templates/_activities-list.scss */
+/* line 41, ../sass/templates/_activities-list.scss */
 .new-activity {
   width: 480px;
 }
-/* line 30, ../sass/templates/_activities-list.scss */
+/* line 43, ../sass/templates/_activities-list.scss */
 .new-activity h3 {
   margin-top: 0;
 }
-/* line 33, ../sass/templates/_activities-list.scss */
+/* line 46, ../sass/templates/_activities-list.scss */
 .new-activity textarea {
   font-size: 18px;
   resize: none;
   padding: .5em;
 }
-/* line 39, ../sass/templates/_activities-list.scss */
+/* line 52, ../sass/templates/_activities-list.scss */
 .new-activity .grid button[type="submit"] {
   margin-top: 1.4em;
 }
-/* line 42, ../sass/templates/_activities-list.scss */
+/* line 55, ../sass/templates/_activities-list.scss */
 .new-activity .grid p {
   padding-left: 2em;
 }
 
-/* line 49, ../sass/templates/_activities-list.scss */
+/* line 62, ../sass/templates/_activities-list.scss */
 .activity-box__title {
   font-size: 18px;
   font-weight: 400;
@@ -2113,104 +2231,105 @@ input[type="submit"]:disabled:hover {
   margin-bottom: 2em;
   position: relative;
 }
-/* line 55, ../sass/templates/_activities-list.scss */
+/* line 68, ../sass/templates/_activities-list.scss */
 .activity-box__title:before {
   display: inline-block;
   margin-right: .5em;
   font-family: "FontAwesome";
 }
 
-/* line 63, ../sass/templates/_activities-list.scss */
+/* line 76, ../sass/templates/_activities-list.scss */
 .activity-box__title--edited:before {
   content: '\f040';
 }
 
-/* line 69, ../sass/templates/_activities-list.scss */
+/* line 82, ../sass/templates/_activities-list.scss */
 .activity-box__title--feedback:before {
   content: '\f087';
 }
 
-/* line 75, ../sass/templates/_activities-list.scss */
+/* line 88, ../sass/templates/_activities-list.scss */
 .activity-box__title--endorsed:before {
   content: '\f040';
 }
 
-/* line 81, ../sass/templates/_activities-list.scss */
+/* line 94, ../sass/templates/_activities-list.scss */
 .activity-box__title--published:before {
   content: '\f00c';
 }
 
-/* line 86, ../sass/templates/_activities-list.scss */
+/* line 99, ../sass/templates/_activities-list.scss */
 .activity-box__list {
   margin-top: 0;
 }
 
-/* line 90, ../sass/templates/_activities-list.scss */
+/* line 103, ../sass/templates/_activities-list.scss */
 .activity-box__empty-state {
   font-size: 18px;
   text-align: center;
   color: #757575;
 }
 
-/* line 96, ../sass/templates/_activities-list.scss */
+/* line 109, ../sass/templates/_activities-list.scss */
 .activity {
   padding: 1em 0;
   background-color: #fff;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
   padding: 10px 20px;
-  margin: 1em 0;
+  margin: .2em 0 1em 0;
 }
 
-/* line 104, ../sass/templates/_activities-list.scss */
+/* line 117, ../sass/templates/_activities-list.scss */
 .activity--edited {
   border-left: 4px solid #e0e0e0;
 }
 
-/* line 108, ../sass/templates/_activities-list.scss */
+/* line 121, ../sass/templates/_activities-list.scss */
 .activity--feedback {
   border-left: 4px solid #f1b17f;
 }
 
-/* line 112, ../sass/templates/_activities-list.scss */
+/* line 125, ../sass/templates/_activities-list.scss */
 .activity--endorsed {
   border-left: 4px solid #66c6ac;
 }
 
-/* line 116, ../sass/templates/_activities-list.scss */
+/* line 129, ../sass/templates/_activities-list.scss */
 .activity--published {
   border-left: 4px solid #6693a5;
 }
 
-/* line 120, ../sass/templates/_activities-list.scss */
+/* line 133, ../sass/templates/_activities-list.scss */
 .activity__title {
   font-weight: 400;
   font-size: 18px;
   margin: 0;
   margin-bottom: .2em;
 }
-/* line 125, ../sass/templates/_activities-list.scss */
+/* line 138, ../sass/templates/_activities-list.scss */
 .activity__title a {
   color: #000;
 }
 
-/* line 130, ../sass/templates/_activities-list.scss */
+/* line 143, ../sass/templates/_activities-list.scss */
 .activity__author {
   margin: 0;
   font-size: 14px;
+  color: #616161;
 }
 
-/* line 135, ../sass/templates/_activities-list.scss */
+/* line 149, ../sass/templates/_activities-list.scss */
 .activity__actions {
   margin-top: .5em;
   border-top: 1px solid #e0e0e0;
   padding-top: .5em;
 }
-/* line 139, ../sass/templates/_activities-list.scss */
-.activity__actions a {
+/* line 153, ../sass/templates/_activities-list.scss */
+.activity__actions .toolbar__item {
   color: #bdbdbd;
 }
-/* line 141, ../sass/templates/_activities-list.scss */
-.activity__actions a:hover {
+/* line 155, ../sass/templates/_activities-list.scss */
+.activity__actions .toolbar__item:hover {
   color: #757575;
 }
 

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -831,6 +831,84 @@ a:hover {
     top: 100%;
   }
 }
+@-webkit-keyframes modal-container {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@-moz-keyframes modal-container {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@keyframes modal-container {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@-webkit-keyframes modal {
+  0% {
+    display: none;
+    opacity: 0;
+    margin-top: 4em;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+@-moz-keyframes modal {
+  0% {
+    display: none;
+    opacity: 0;
+    margin-top: 4em;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+@keyframes modal {
+  0% {
+    display: none;
+    opacity: 0;
+    margin-top: 4em;
+  }
+  1% {
+    display: block;
+  }
+  100% {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
 /*------------------------------------*\
     # Components
 \*------------------------------------*/
@@ -1297,9 +1375,9 @@ input[type="submit"]:disabled:hover {
 
 /* line 1, ../sass/components/_modal.scss */
 .modal-container {
-  -webkit-transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
-  -moz-transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
-  transition: opacity 0.2s ease-out, margin-top 0.1s ease-out;
+  -webkit-animation: modal-container 0.2s ease-out;
+  -moz-animation: modal-container 0.2s ease-out;
+  animation: modal-container 0.2s ease-out;
   display: -webkit-box;
   display: -moz-box;
   display: box;
@@ -1332,19 +1410,23 @@ input[type="submit"]:disabled:hover {
   right: 0;
   background-color: #424242;
   background-color: rgba(0, 0, 0, 0.15);
-  z-index: -2;
   opacity: 0;
   margin-top: -2em;
+  display: none;
 }
 /* line 16, ../sass/components/_modal.scss */
 .modal-container.is-open {
+  display: block;
+  display: flex;
   margin-top: 0;
-  z-index: 9999;
   opacity: 1;
 }
 
-/* line 22, ../sass/components/_modal.scss */
+/* line 23, ../sass/components/_modal.scss */
 .modal {
+  -webkit-animation: modal 0.2s ease-out;
+  -moz-animation: modal 0.2s ease-out;
+  animation: modal 0.2s ease-out;
   background-color: #fff;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
   width: 600px;
@@ -1361,7 +1443,7 @@ input[type="submit"]:disabled:hover {
 .modal:after {
   clear: both;
 }
-/* line 30, ../sass/components/_modal.scss */
+/* line 32, ../sass/components/_modal.scss */
 .lt-ie10 .modal {
   margin-top: 4em;
 }
@@ -1371,7 +1453,7 @@ input[type="submit"]:disabled:hover {
   position: relative;
 }
 /* line 4, ../sass/components/_tooltip.scss */
-.tooltipped:hover .tooltipped__tt-container {
+.tooltipped:hover .tooltipped__tt {
   -webkit-animation: tooltip 0.2s ease-out;
   -moz-animation: tooltip 0.2s ease-out;
   animation: tooltip 0.2s ease-out;
@@ -1381,18 +1463,17 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 13, ../sass/components/_tooltip.scss */
-.tooltipped__tt-container {
+.tooltipped__tt {
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  -o-transform: translateX(-50%);
+  transform: translateX(-50%);
   display: none;
   position: absolute;
   left: 50%;
   top: 120%;
   margin-top: 6px;
-}
-
-/* line 21, ../sass/components/_tooltip.scss */
-.tooltipped__tt {
-  position: relative;
-  left: -50%;
   background-color: #eeeeee;
   border: 1px solid #e0e0e0;
   color: #000;
@@ -1401,8 +1482,9 @@ input[type="submit"]:disabled:hover {
   text-align: center;
   font-weight: 400;
   font-size: 12px;
+  z-index: 9999;
 }
-/* line 33, ../sass/components/_tooltip.scss */
+/* line 30, ../sass/components/_tooltip.scss */
 .tooltipped__tt:before {
   position: absolute;
   left: 50%;
@@ -1415,6 +1497,14 @@ input[type="submit"]:disabled:hover {
   border-bottom: 7.5px solid #e0e0e0;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
+}
+/* line 40, ../sass/components/_tooltip.scss */
+.lt-ie10 .tooltipped__tt {
+  margin-left: -50%;
+}
+/* line 42, ../sass/components/_tooltip.scss */
+.lt-ie10 .tooltipped__tt:before {
+  left: 5px;
 }
 
 /* line 1, ../sass/components/_alerts.scss */
@@ -1846,28 +1936,38 @@ input[type="submit"]:disabled:hover {
 .activity-progress__item.is-completed:before {
   background-color: #757575;
 }
-/* line 49, ../sass/components/_activity-progress.scss */
+/* line 46, ../sass/components/_activity-progress.scss */
+.activity-progress__item.is-completed:after {
+  width: 0;
+  height: 0;
+  content: '';
+  z-index: 2;
+  border-left: 9px solid #757575;
+  border-bottom: 6px solid transparent;
+  border-top: 6px solid transparent;
+}
+/* line 52, ../sass/components/_activity-progress.scss */
 .activity-progress__item--edited.is-completed .activity-progress__icon {
   border-color: #616161;
   color: #616161;
 }
-/* line 57, ../sass/components/_activity-progress.scss */
+/* line 60, ../sass/components/_activity-progress.scss */
 .activity-progress__item--requested.is-completed .activity-progress__icon {
   border-color: #f1b17f;
   color: #f1b17f;
 }
-/* line 65, ../sass/components/_activity-progress.scss */
+/* line 68, ../sass/components/_activity-progress.scss */
 .activity-progress__item--endorsed.is-completed .activity-progress__icon {
   border-color: #66c6ac;
   color: #66c6ac;
 }
-/* line 73, ../sass/components/_activity-progress.scss */
+/* line 76, ../sass/components/_activity-progress.scss */
 .activity-progress__item--published.is-completed .activity-progress__icon {
   border-color: #6693a5;
   color: #6693a5;
 }
 
-/* line 81, ../sass/components/_activity-progress.scss */
+/* line 84, ../sass/components/_activity-progress.scss */
 .activity-progress__label {
   font-size: 16px;
   color: #9e9e9e;
@@ -1875,17 +1975,16 @@ input[type="submit"]:disabled:hover {
   margin-top: .5em;
   margin-bottom: 0;
 }
-/* line 87, ../sass/components/_activity-progress.scss */
+/* line 90, ../sass/components/_activity-progress.scss */
 .is-completed .activity-progress__label {
   color: #000;
   font-weight: 400;
 }
 
-/* line 93, ../sass/components/_activity-progress.scss */
+/* line 96, ../sass/components/_activity-progress.scss */
 .activity-progress__icon {
   display: inline-block;
   position: relative;
-  z-index: 1;
   border-radius: 50%;
   height: 2.5em;
   width: 2.5em;
@@ -1894,26 +1993,25 @@ input[type="submit"]:disabled:hover {
   border: 2px solid #e0e0e0;
   color: #9e9e9e;
 }
-/* line 104, ../sass/components/_activity-progress.scss */
+/* line 106, ../sass/components/_activity-progress.scss */
 .activity-progress__icon:before {
   font-family: "FontAwesome";
   position: relative;
   top: -1px;
 }
-/* line 110, ../sass/components/_activity-progress.scss */
+/* line 112, ../sass/components/_activity-progress.scss */
 .activity-progress__item--edited .activity-progress__icon:before {
   content: '\f040';
 }
-/* line 115, ../sass/components/_activity-progress.scss */
+/* line 117, ../sass/components/_activity-progress.scss */
 .activity-progress__item--requested .activity-progress__icon:before {
-  top: -2px;
   content: '\f06e';
 }
-/* line 121, ../sass/components/_activity-progress.scss */
+/* line 122, ../sass/components/_activity-progress.scss */
 .activity-progress__item--endorsed .activity-progress__icon:before {
   content: '\f087';
 }
-/* line 126, ../sass/components/_activity-progress.scss */
+/* line 127, ../sass/components/_activity-progress.scss */
 .activity-progress__item--published .activity-progress__icon:before {
   content: '\f00c';
 }
@@ -2161,16 +2259,26 @@ input[type="submit"]:disabled:hover {
 .activity-list__states {
   padding: 1em 0;
 }
-/* line 15, ../sass/templates/_activities-list.scss */
+/* line 16, ../sass/templates/_activities-list.scss */
 .activity-list__states .activity-progress__item:before {
   background-color: #e0e0e0;
 }
-/* line 18, ../sass/templates/_activities-list.scss */
+/* line 19, ../sass/templates/_activities-list.scss */
+.activity-list__states .activity-progress__item:after {
+  width: 0;
+  height: 0;
+  content: '';
+  z-index: 2;
+  border-left: 9px solid #e0e0e0;
+  border-bottom: 6px solid transparent;
+  border-top: 6px solid transparent;
+}
+/* line 23, ../sass/templates/_activities-list.scss */
 .activity-list__states .activity-progress__label {
   font-weight: 300;
 }
 
-/* line 23, ../sass/templates/_activities-list.scss */
+/* line 28, ../sass/templates/_activities-list.scss */
 .activities-list__main {
   display: -webkit-box;
   display: -moz-box;
@@ -2196,7 +2304,7 @@ input[type="submit"]:disabled:hover {
   display: block;
 }
 
-/* line 29, ../sass/templates/_activities-list.scss */
+/* line 34, ../sass/templates/_activities-list.scss */
 .activity-box {
   -webkit-box-flex: 1;
   -moz-box-flex: 1;
@@ -2210,36 +2318,37 @@ input[type="submit"]:disabled:hover {
   padding: 0 20px 2em 20px;
   border-right: 1px solid #eeeeee;
   overflow: auto;
+  overflow-x: hidden;
 }
-/* line 36, ../sass/templates/_activities-list.scss */
+/* line 42, ../sass/templates/_activities-list.scss */
 .activity-box:last-child {
   border-right: 0;
 }
 
-/* line 41, ../sass/templates/_activities-list.scss */
+/* line 47, ../sass/templates/_activities-list.scss */
 .new-activity {
   width: 480px;
 }
-/* line 43, ../sass/templates/_activities-list.scss */
+/* line 49, ../sass/templates/_activities-list.scss */
 .new-activity h3 {
   margin-top: 0;
 }
-/* line 46, ../sass/templates/_activities-list.scss */
+/* line 52, ../sass/templates/_activities-list.scss */
 .new-activity textarea {
   font-size: 18px;
   resize: none;
   padding: .5em;
 }
-/* line 52, ../sass/templates/_activities-list.scss */
+/* line 58, ../sass/templates/_activities-list.scss */
 .new-activity .grid button[type="submit"] {
   margin-top: 1.4em;
 }
-/* line 55, ../sass/templates/_activities-list.scss */
+/* line 61, ../sass/templates/_activities-list.scss */
 .new-activity .grid p {
   padding-left: 2em;
 }
 
-/* line 62, ../sass/templates/_activities-list.scss */
+/* line 68, ../sass/templates/_activities-list.scss */
 .activity-box__title {
   font-size: 18px;
   font-weight: 400;
@@ -2247,46 +2356,46 @@ input[type="submit"]:disabled:hover {
   margin-bottom: 2em;
   position: relative;
 }
-/* line 68, ../sass/templates/_activities-list.scss */
+/* line 74, ../sass/templates/_activities-list.scss */
 .activity-box__title:before {
   display: inline-block;
   margin-right: .5em;
   font-family: "FontAwesome";
 }
 
-/* line 76, ../sass/templates/_activities-list.scss */
+/* line 82, ../sass/templates/_activities-list.scss */
 .activity-box__title--edited:before {
   content: '\f040';
 }
 
-/* line 82, ../sass/templates/_activities-list.scss */
+/* line 88, ../sass/templates/_activities-list.scss */
 .activity-box__title--feedback:before {
   content: '\f087';
 }
 
-/* line 88, ../sass/templates/_activities-list.scss */
+/* line 94, ../sass/templates/_activities-list.scss */
 .activity-box__title--endorsed:before {
   content: '\f040';
 }
 
-/* line 94, ../sass/templates/_activities-list.scss */
+/* line 100, ../sass/templates/_activities-list.scss */
 .activity-box__title--published:before {
   content: '\f00c';
 }
 
-/* line 99, ../sass/templates/_activities-list.scss */
+/* line 105, ../sass/templates/_activities-list.scss */
 .activity-box__list {
   margin-top: 0;
 }
 
-/* line 103, ../sass/templates/_activities-list.scss */
+/* line 109, ../sass/templates/_activities-list.scss */
 .activity-box__empty-state {
   font-size: 18px;
   text-align: center;
   color: #757575;
 }
 
-/* line 109, ../sass/templates/_activities-list.scss */
+/* line 115, ../sass/templates/_activities-list.scss */
 .activity {
   padding: 1em 0;
   background-color: #fff;
@@ -2295,39 +2404,39 @@ input[type="submit"]:disabled:hover {
   margin: .2em 0 1em 0;
 }
 
-/* line 117, ../sass/templates/_activities-list.scss */
+/* line 123, ../sass/templates/_activities-list.scss */
 .activity--edited {
   border-left: 4px solid #757575;
 }
 
-/* line 121, ../sass/templates/_activities-list.scss */
+/* line 127, ../sass/templates/_activities-list.scss */
 .activity--feedback {
   border-left: 4px solid #f1b17f;
 }
 
-/* line 125, ../sass/templates/_activities-list.scss */
+/* line 131, ../sass/templates/_activities-list.scss */
 .activity--endorsed {
   border-left: 4px solid #66c6ac;
 }
 
-/* line 129, ../sass/templates/_activities-list.scss */
+/* line 135, ../sass/templates/_activities-list.scss */
 .activity--published {
   border-left: 4px solid #6693a5;
 }
 
-/* line 133, ../sass/templates/_activities-list.scss */
+/* line 139, ../sass/templates/_activities-list.scss */
 .activity__title {
   font-weight: 400;
   font-size: 18px;
   margin: 0;
   margin-bottom: .2em;
 }
-/* line 138, ../sass/templates/_activities-list.scss */
+/* line 144, ../sass/templates/_activities-list.scss */
 .activity__title a {
   color: #000;
 }
 
-/* line 143, ../sass/templates/_activities-list.scss */
+/* line 149, ../sass/templates/_activities-list.scss */
 .activity__author {
   margin: 0;
   font-size: 14px;
@@ -2335,7 +2444,7 @@ input[type="submit"]:disabled:hover {
   font-weight: 400;
 }
 
-/* line 150, ../sass/templates/_activities-list.scss */
+/* line 156, ../sass/templates/_activities-list.scss */
 .activity__actions {
   width: auto;
   margin-top: .5em;
@@ -2346,11 +2455,11 @@ input[type="submit"]:disabled:hover {
   border-top: 1px solid #eeeeee;
   padding-top: .5em;
 }
-/* line 163, ../sass/templates/_activities-list.scss */
+/* line 169, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item {
   color: #bdbdbd;
 }
-/* line 165, ../sass/templates/_activities-list.scss */
+/* line 171, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item:hover {
   color: #757575;
 }

--- a/chime/static/stylesheets/main.css
+++ b/chime/static/stylesheets/main.css
@@ -2436,14 +2436,35 @@ input[type="submit"]:disabled:hover {
 }
 
 /* line 153, ../sass/templates/_activities-list.scss */
-.activity__author {
+.activity__status {
   margin: 0;
   font-size: 14px;
   color: #9e9e9e;
   font-weight: 400;
+  width: 100%;
 }
 
-/* line 160, ../sass/templates/_activities-list.scss */
+/* line 162, ../sass/templates/_activities-list.scss */
+.activity__author {
+  white-space: pre;
+  /* CSS 2.0 */
+  white-space: pre-wrap;
+  /* CSS 2.1 */
+  white-space: pre-line;
+  /* CSS 3.0 */
+  white-space: -pre-wrap;
+  /* Opera 4-6 */
+  white-space: -o-pre-wrap;
+  /* Opera 7 */
+  white-space: -moz-pre-wrap;
+  /* Mozilla */
+  white-space: -hp-pre-wrap;
+  /* HP Printers */
+  word-wrap: break-word;
+  /* IE 5+ */
+}
+
+/* line 173, ../sass/templates/_activities-list.scss */
 .activity__actions {
   width: auto;
   margin-top: .5em;
@@ -2454,11 +2475,11 @@ input[type="submit"]:disabled:hover {
   border-top: 1px solid #eeeeee;
   padding-top: .5em;
 }
-/* line 173, ../sass/templates/_activities-list.scss */
+/* line 186, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item {
   color: #bdbdbd;
 }
-/* line 175, ../sass/templates/_activities-list.scss */
+/* line 188, ../sass/templates/_activities-list.scss */
 .activity__actions .toolbar__item:hover {
   color: #757575;
 }

--- a/chime/static/stylesheets/styleguide.css
+++ b/chime/static/stylesheets/styleguide.css
@@ -449,22 +449,22 @@ th {
   padding: 0;
 }
 
-/* line 42, ../sass/core/_utilities.scss */
+/* line 41, ../sass/core/_utilities.scss */
 .is-hidden {
   display: none !important;
 }
 
-/* line 46, ../sass/core/_utilities.scss */
+/* line 45, ../sass/core/_utilities.scss */
 .text-red {
   color: #aa1c3a !important;
 }
 
-/* line 50, ../sass/core/_utilities.scss */
+/* line 49, ../sass/core/_utilities.scss */
 .text-green {
   color: #00a175 !important;
 }
 
-/* line 54, ../sass/core/_utilities.scss */
+/* line 53, ../sass/core/_utilities.scss */
 .text-detail {
   font-size: 14px;
   font-weight: 400;

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -8,8 +8,9 @@
 {% endblock %}
 
 {% block content %}
+    <!-- template name: {{ template_name }} -->
     <div class="row row--main activities-list__header">
-      <p class="row__left">A view of work in progress on the site</p>
+      <p class="row__left">A view of work in progress by you and your collegues</p>
       <div class="toolbar toobar--right row__right">
         <a class="button button--green button--medium button--new-activity">Start a new activity</a>
       </div>
@@ -18,19 +19,19 @@
     <ul class="activity-list__states grid row">
         <li class="activity-progress__item activity-progress__item--edited is-completed grid__item width-one-fourth">
             <div class="activity-progress__icon"></div>
-            <p class="activity-progress__label">Edits Made</p>
+            <p class="activity-progress__label">In progress</p>
         </li>
         <li class="activity-progress__item  activity-progress__item--requested is-completed grid__item width-one-fourth">
             <div class="activity-progress__icon"></div>
-            <p class="activity-progress__label">Feedback Requested</p>
+            <p class="activity-progress__label">Feedback needed</p>
         </li>
         <li class="activity-progress__item  activity-progress__item--endorsed is-completed grid__item width-one-fourth">
             <div class="activity-progress__icon"></div>
-            <p class="activity-progress__label">Edits Endorsed</p>
+            <p class="activity-progress__label">Ready to publish</p>
         </li>
         <li class="activity-progress__item activity-progress__item--published is-completed grid__item width-one-fourth end-row">
             <div class="activity-progress__icon "></div>
-            <p class="activity-progress__label">Published</p>
+            <p class="activity-progress__label">Recently published</p>
         </li>
     </ul>
 
@@ -58,13 +59,13 @@
 {% endblock %}
 
 {% macro activity_box(state_activities, activity_state) -%}
-<div class="activity-box">
+<div class="activity-box activity-box--{{ activity_state }}">
     <ul class="activity-box__list">
     {% for activity in state_activities %}
      <li class="activity activity--{{activity_state}}">
       <p class="activity__title"><a href="{{ activity.edit_path }}">{{ activity.task_description }}</a></p>
       <div class="row">
-        <p class="activity__author row__left">Last edited by {{ activity.last_edited_email }}</p>
+        <p class="activity__author row__left">edited {{ activity.date_updated }} by {{ activity.last_edited_email }}</p>
         <form action="/update" method="POST" class="row__right">
           <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
         </form>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -64,13 +64,14 @@
     {% for activity in state_activities %}
      <li class="activity activity--{{ activity_state }}">
       <!-- branch: {{ activity.safe_branch }} -->
-      <p class="activity__title"><a href="{{ activity.edit_path }}">{{ activity.task_description }}</a></p>
+      <p class="activity__title"><a href="{{ activity.overview_path }}">{{ activity.task_description }}</a></p>
       <div class="row">
         <p class="activity__author row__left">edited {{ activity.date_updated }} by {{ activity.last_edited_email }}</p>
         <form action="/update" method="POST" class="row__right">
           <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
         </form>
       </div>
+      {% if activity_state != "published" %}
       <div class="activity__actions row">
         <div class="row__left toolbar toolbar--left">
           <a class="toolbar__item tooltipped" href="{{ activity.edit_path }}">
@@ -82,6 +83,7 @@
             <span class="tooltipped__tt">Overview</span>
           </a>
         </div>
+        
         <div class="row__right toolbar toolbar--right">
           <form action="/update" method="POST" class="toolbar__item">
             <button class="toolbar__item button--nostyle tooltipped" type="submit" name="abandon" value="Delete" id="{{ activity.safe_branch }}-delete">
@@ -92,6 +94,7 @@
           </form>
         </div>
       </div>
+      {% endif %}
     </li>
     {% endfor %}
   </ul>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -35,7 +35,7 @@
         </li>
     </ul>
 
-    <div class="activities-list__main row row--main col__flex">
+    <div class="activities-list__main row row--main col__flex grid">
       {{ activity_box(in_progress_activities, "edited")}}
       {{ activity_box(feedback_activities, "feedback")}}
       {{ activity_box(endorsed_activities, "endorsed")}}
@@ -59,7 +59,7 @@
 {% endblock %}
 
 {% macro activity_box(state_activities, activity_state) -%}
-<div class="activity-box activity-box--{{ activity_state }}">
+<div class="activity-box activity-box--{{ activity_state }} grid__item width-one-fourth">
     <ul class="activity-box__list" id="activity-list-{{ activity_state }}">
     {% for activity in state_activities %}
      <li class="activity activity--{{ activity_state }}">
@@ -75,24 +75,18 @@
         <div class="row__left toolbar toolbar--left">
           <a class="toolbar__item tooltipped" href="{{ activity.edit_path }}">
             <span class="fa fa-files-o"></span>
-            <span class="tooltipped__tt-container">
-              <span class="tooltipped__tt">Content</span>
-            </span>
+            <span class="tooltipped__tt">Content</span>
           </a>
           <a class="toolbar__item tooltipped" href="{{ activity.overview_path }}">
             <span class="fa fa-calendar-o"></span>
-            <span class="tooltipped__tt-container">
-              <span class="tooltipped__tt">Overview</span>
-            </span>
+            <span class="tooltipped__tt">Overview</span>
           </a>
         </div>
         <div class="row__right toolbar toolbar--right">
           <form action="/update" method="POST" class="toolbar__item">
             <button class="toolbar__item button--nostyle tooltipped" type="submit" name="abandon" value="Delete" id="{{ activity.safe_branch }}-delete">
               <span class="fa fa-trash"></span>
-              <span class="tooltipped__tt-container">
-                <span class="tooltipped__tt">Delete</span>
-              </span>
+              <span class="tooltipped__tt">Delete</span>
             </button>
             <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
           </form>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -66,7 +66,7 @@
       <!-- branch: {{ activity.safe_branch }} -->
       <p class="activity__title"><a href="{{ activity.overview_path }}">{{ activity.task_description }}</a></p>
       <div class="row">
-        <p class="activity__author row__left">edited {{ activity.date_updated }} by {{ activity.last_edited_email }}</p>
+        <p class="activity__status row__left">edited <span class="activity__date">{{ activity.date_updated }}</span> by <span class="activity__author">{{ activity.last_edited_email }}</span></p>
         <form action="/update" method="POST" class="row__right">
           <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
         </form>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -12,7 +12,7 @@
     <div class="row row--main activities-list__header">
       <p class="row__left">A view of work in progress by you and your collegues</p>
       <div class="toolbar toobar--right row__right">
-        <a class="button button--green button--medium button--new-activity">Start a new activity</a>
+        <a class="button button--green button--medium button--new-activity" href="/start-activity">Start a new activity</a>
       </div>
     </div>
 
@@ -42,7 +42,7 @@
       {{ activity_box(published_activities.activities, "published")}}
     </div>
 
-    <div class="modal-container">
+    <div class="modal-container {% if show_new_activity_modal %}is-open{% endif %}">
     <div class="new-activity modal">
       <h3>Let teammates know what public need you are addressing.</h3>
       <form action="/start" method="POST">
@@ -50,7 +50,7 @@
         <input name="task_beneficiary" type="hidden" class="need"/>
         <p class="text-detail width-three-fourths">Starting an activity gives you your own copy of the site to work in. Activities need to be reviewed by someone else in order to go live.</p> 
         <div class="toolbar toolbar--right">
-          <a href="#" class="toolbar__item button button--medium button--close-modal">Cancel</a>
+          <a href="/activity" class="toolbar__item button button--medium button--close-modal">Cancel</a>
           <button type="submit" class="toolbar__item button button--medium button--green button--create-activity">Create</button>
         </div>         
       </form> 
@@ -96,6 +96,8 @@
       </div>
       {% endif %}
     </li>
+    {% else %}
+    <div class="activity-box__empty-state">Empty</div>
     {% endfor %}
   </ul>
 </div>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -3,77 +3,62 @@
 {% set template_name = 'activities-list' %}
 {% block body_class %}{{template_name}}{% endblock %}
 
-{% block content %}
-    <!-- template name: {{ template_name }} -->
-    <div class="activities-list__main row row--main grid col__flex">
-      <div class="current-tasks grid__item width-two-thirds">
-        <h2 class="current-tasks__title">Current Activities</h2>
-        {% if activities | length == 0 %}
-
-          <p class="current-tasks__empty-description">Doesn't look like anyone's working on anything at the moment. You should hop to it!</p>
-        {% else %}
-          <p class="current-tasks__description">Work that's already underway by you and your colleagues.</p>
-          <ul class="current-tasks__list" id="current-activities">
-          {% for activity in activities %}
-           <li class="current-task">
-            <p class="current-task__title"><a href="{{ activity.edit_path }}">{{ activity.task_description }}</a></p>
-            <div class="current-task__details row">
-              <p class="current-task__author row__left">Last edited by {{ activity.last_edited_email }}</p>
-              <div class="current-task__actions row__right toolbar--right">
-                  {% if activity.review_authorized %}
-                    {% if activity.review_state == config.REVIEW_STATE_EDITED %}
-                    <a href="{{ activity.overview_path }}" class="toolbar__item button">Unreviewed Edits</a>
-                    {% elif activity.review_state == config.REVIEW_STATE_FEEDBACK %}
-                    <a href="{{ activity.overview_path }}" class="toolbar__item button">Feedback requested</a>
-                    {% elif activity.review_state == config.REVIEW_STATE_ENDORSED %}
-                    <a href="{{ activity.overview_path }}" class="toolbar__item button">Ready to publish</a>
-                    {% elif activity.review_state == config.REVIEW_STATE_PUBLISHED %}
-                    <a href="{{ activity.overview_path }}" class="toolbar__item button">Published</a>
-                    {% endif %}
-                  {% else %}
-                    {% if activity.review_state == config.REVIEW_STATE_FEEDBACK %}
-                    <a href="{{ activity.overview_path }}" class="toolbar__item button">Waiting for feedback</a>
-                    {% endif %}
-                  {% endif %}
-                  <form action="/update" method="POST" class="toolbar__item">
-                    <button class="toolbar__item button button--red" type="submit" name="abandon" value="Delete" id="{{ activity.safe_branch }}-delete">Delete</button>
-                    <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
-                  </form>
-                </div>
-              </div>
-            </li>
-          {% endfor %}
-          </ul>
-        {% endif %}
-        {% if published_activities.count > 0 %}
-          <h2 class="current-tasks__title">Recently Published Activities</h2>
-          <p class="current-tasks__description">The {{ published_activities.description }} most recently published to the live site.</p>
-          <ul class="current-tasks__list" id="published-activities">
-          {% for activity in published_activities.activities %}
-           <li class="current-task">
-            <!-- branch: {{ activity.safe_branch }} -->
-            <p class="current-task__title">{{ activity.task_description }}</p>
-            <div class="current-task__details row">
-              <p class="current-task__author row__left">Published {{ activity.date_updated }} by {{ activity.last_edited_email }}</p>
-              <div class="current-task__actions row__right toolbar--right">
-                  <a href="{{ activity.overview_path }}" class="toolbar__item button">Published</a>
-              </div>
-            </li>
-          {% endfor %}
-          </ul>
-        {% endif %}
-        </div>
-        <div class="new-task grid__item width-one-third end-row">
-          <h2 class="new-task__title">Start a new activity</h2>
-          <form action="/start" method="POST" class="new-task__form">
-            <p class="new-task__description">Let teammates know what public need you are addressing.</p>
-            <textarea name="task_description" placeholder="clarifying the permitting application process for business owners" class="new-task__textarea" {% if task_description %} value="{{ task_description }}"{% endif %}></textarea>
-            <div class="row new-task__actions">
-              <button type="submit" class="button button--green button--medium" id="create-activity-button">Create</button>
-            </div>
-          </form> 
-          <p class="text-detail">Starting an activity gives you your own copy of the site to work in. Changes in an activity need to be reviewed by someone else in order to go live.</p>
-        </div>
-    </div>
+{% block scripts %}
+<script src="static/javascript/activities-list.js"></script>
 {% endblock %}
 
+{% block content %}
+    <div class="row row--main activities-list__header">
+      <p class="row__left">A view of work in progress on the site</p>
+      <div class="toolbar toobar--right row__right">
+        <a class="button button--green button--medium button--new-activity">Start a new activity</a>
+      </div>
+    </div>
+    <div class="activities-list__main row row--main col__flex">
+      {{ activity_box(in_progress_activities, "edited")}}
+      {{ activity_box(feedback_activities, "feedback")}}
+      {{ activity_box(endorsed_activities, "endorsed")}}
+      {{ activity_box(published_activities.activities, "published")}}
+    </div>
+    <div class="modal-container">
+    <div class="new-activity modal">
+      <h3>Let teammates know what public need you are addressing.</h3>
+      <form action="/start" method="POST">
+        <textarea type="text" name="task_description" placeholder="clarifying the permitting application process for business owners" class="need"></textarea>
+        <input name="task_beneficiary" type="hidden" class="need"/>
+        <p class="text-detail width-three-fourths">Starting an activity gives you your own copy of the site to work in. Activities need to be reviewed by someone else in order to go live.</p> 
+        <div class="toolbar toolbar--right">
+          <a href="#" class="toolbar__item button button--medium button--close-modal">Cancel</a>
+          <button type="submit" class="toolbar__item button button--medium button--green button--create-activity">Create</button>
+        </div>         
+      </form> 
+    </div>
+  </div>
+{% endblock %}
+
+{% macro activity_box(state_activities, activity_state) -%}
+<div class="activity-box">
+    <ul class="activity-box__list">
+    {% for activity in state_activities %}
+     <li class="activity activity--{{activity_state}}">
+      <p class="activity__title"><a href="{{ activity.edit_path }}">{{ activity.task_description }}</a></p>
+      <div class="row">
+        <p class="activity__author row__left">Last edited by {{ activity.last_edited_email }}</p>
+        <form action="/update" method="POST" class="row__right">
+          <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
+        </form>
+      </div>
+      <div class="activity__actions row">
+        <div class="row__left toolbar toolbar--left">
+          <a class="toolbar__item" href="{{ activity.edit_path }}"><span class="fa fa-files-o"></span></a>
+          <a class="toolbar__item" href="{{ activity.overview_path }}"><span class="fa fa-calendar-o"></span></a>
+        </div>
+        <div class="row__right toolbar toolbar--right">
+          <a href="" class="toolbar__item"><span class="fa fa-trash"></span></a>
+        </div>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{%- endmacro %}

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -12,7 +12,7 @@
     <div class="row row--main activities-list__header">
       <p class="row__left">A view of work in progress by you and your colleagues</p>
       <div class="toolbar toobar--right row__right">
-        <a class="button button--green button--medium button--new-activity" href="/start-activity">Start a new activity</a>
+        <a id="submit-start-activity" class="button button--green button--medium button--new-activity" href="/start-activity">Start a new activity</a>
       </div>
     </div>
 
@@ -36,10 +36,10 @@
     </ul>
 
     <div class="activities-list__main row row--main col__flex grid">
-      {{ activity_box(in_progress_activities, "edited")}}
-      {{ activity_box(feedback_activities, "feedback")}}
-      {{ activity_box(endorsed_activities, "endorsed")}}
-      {{ activity_box(published_activities.activities, "published")}}
+      {{ activity_box(activities.in_progress, "edited")}}
+      {{ activity_box(activities.feedback, "feedback")}}
+      {{ activity_box(activities.endorsed, "endorsed")}}
+      {{ activity_box(activities.published, "published")}}
     </div>
 
     <div class="modal-container {% if show_new_activity_modal %}is-open{% endif %}">
@@ -47,11 +47,10 @@
       <h3>Let teammates know what public need you are addressing.</h3>
       <form action="/start" method="POST">
         <textarea type="text" name="task_description" placeholder="clarifying the permitting application process for business owners" class="need"></textarea>
-        <input name="task_beneficiary" type="hidden" class="need"/>
         <p class="text-detail width-three-fourths">Starting an activity gives you your own copy of the site to work in. Activities need to be reviewed by someone else in order to go live.</p> 
         <div class="toolbar toolbar--right">
           <a href="/activity" class="toolbar__item button button--medium button--close-modal">Cancel</a>
-          <button type="submit" class="toolbar__item button button--medium button--green button--create-activity">Create</button>
+          <button id="submit-create-activity" type="submit" class="toolbar__item button button--medium button--green button--create-activity">Create</button>
         </div>         
       </form> 
     </div>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -60,9 +60,10 @@
 
 {% macro activity_box(state_activities, activity_state) -%}
 <div class="activity-box activity-box--{{ activity_state }}">
-    <ul class="activity-box__list">
+    <ul class="activity-box__list" id="activity-list-{{ activity_state }}">
     {% for activity in state_activities %}
-     <li class="activity activity--{{activity_state}}">
+     <li class="activity activity--{{ activity_state }}">
+      <!-- branch: {{ activity.safe_branch }} -->
       <p class="activity__title"><a href="{{ activity.edit_path }}">{{ activity.task_description }}</a></p>
       <div class="row">
         <p class="activity__author row__left">edited {{ activity.date_updated }} by {{ activity.last_edited_email }}</p>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -10,7 +10,7 @@
 {% block content %}
     <!-- template name: {{ template_name }} -->
     <div class="row row--main activities-list__header">
-      <p class="row__left">A view of work in progress by you and your collegues</p>
+      <p class="row__left">A view of work in progress by you and your colleagues</p>
       <div class="toolbar toobar--right row__right">
         <a class="button button--green button--medium button--new-activity" href="/start-activity">Start a new activity</a>
       </div>

--- a/chime/templates/activities-list.html
+++ b/chime/templates/activities-list.html
@@ -14,12 +14,33 @@
         <a class="button button--green button--medium button--new-activity">Start a new activity</a>
       </div>
     </div>
+
+    <ul class="activity-list__states grid row">
+        <li class="activity-progress__item activity-progress__item--edited is-completed grid__item width-one-fourth">
+            <div class="activity-progress__icon"></div>
+            <p class="activity-progress__label">Edits Made</p>
+        </li>
+        <li class="activity-progress__item  activity-progress__item--requested is-completed grid__item width-one-fourth">
+            <div class="activity-progress__icon"></div>
+            <p class="activity-progress__label">Feedback Requested</p>
+        </li>
+        <li class="activity-progress__item  activity-progress__item--endorsed is-completed grid__item width-one-fourth">
+            <div class="activity-progress__icon"></div>
+            <p class="activity-progress__label">Edits Endorsed</p>
+        </li>
+        <li class="activity-progress__item activity-progress__item--published is-completed grid__item width-one-fourth end-row">
+            <div class="activity-progress__icon "></div>
+            <p class="activity-progress__label">Published</p>
+        </li>
+    </ul>
+
     <div class="activities-list__main row row--main col__flex">
       {{ activity_box(in_progress_activities, "edited")}}
       {{ activity_box(feedback_activities, "feedback")}}
       {{ activity_box(endorsed_activities, "endorsed")}}
       {{ activity_box(published_activities.activities, "published")}}
     </div>
+
     <div class="modal-container">
     <div class="new-activity modal">
       <h3>Let teammates know what public need you are addressing.</h3>
@@ -50,11 +71,29 @@
       </div>
       <div class="activity__actions row">
         <div class="row__left toolbar toolbar--left">
-          <a class="toolbar__item" href="{{ activity.edit_path }}"><span class="fa fa-files-o"></span></a>
-          <a class="toolbar__item" href="{{ activity.overview_path }}"><span class="fa fa-calendar-o"></span></a>
+          <a class="toolbar__item tooltipped" href="{{ activity.edit_path }}">
+            <span class="fa fa-files-o"></span>
+            <span class="tooltipped__tt-container">
+              <span class="tooltipped__tt">Content</span>
+            </span>
+          </a>
+          <a class="toolbar__item tooltipped" href="{{ activity.overview_path }}">
+            <span class="fa fa-calendar-o"></span>
+            <span class="tooltipped__tt-container">
+              <span class="tooltipped__tt">Overview</span>
+            </span>
+          </a>
         </div>
         <div class="row__right toolbar toolbar--right">
-          <a href="" class="toolbar__item"><span class="fa fa-trash"></span></a>
+          <form action="/update" method="POST" class="toolbar__item">
+            <button class="toolbar__item button--nostyle tooltipped" type="submit" name="abandon" value="Delete" id="{{ activity.safe_branch }}-delete">
+              <span class="fa fa-trash"></span>
+              <span class="tooltipped__tt-container">
+                <span class="tooltipped__tt">Delete</span>
+              </span>
+            </button>
+            <input type="hidden" name="branch" value="{{ activity.safe_branch }}">
+          </form>
         </div>
       </div>
     </li>

--- a/chime/templates/activity-overview.html
+++ b/chime/templates/activity-overview.html
@@ -11,7 +11,6 @@
 {% block scripts %}
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="/static/javascript/activity-summary.js"></script>
 
 {% endblock%}
 
@@ -37,27 +36,27 @@
                 {% set review_step = 4 %}
             {% endif %}
 
-            <li class="activity-progress__item {% if review_step > 0 %}is-completed{% endif %} grid__item width-one-fourth">
-                <div class="activity-progress__icon fa fa-pencil"></div>
+            <li class="activity-progress__item  activity-progress__item--edited {% if review_step > 0 %}is-completed{% endif %} grid__item width-one-fourth">
+                <div class="activity-progress__icon"></div>
                 <p class="activity-progress__label">Edits Made</p>
             </li>
-            <li class="activity-progress__item {% if review_step > 1 %}is-completed{% endif %} grid__item width-one-fourth">
-                <div class="activity-progress__icon fa fa-eye"></div>
+            <li class="activity-progress__item  activity-progress__item--requested {% if review_step > 1 %}is-completed{% endif %} grid__item width-one-fourth">
+                <div class="activity-progress__icon"></div>
                 <p class="activity-progress__label">Feedback Requested</p>
             </li>
-            <li class="activity-progress__item {% if review_step > 2 %}is-completed{% endif %} grid__item width-one-fourth">
-                <div class="activity-progress__icon fa fa-thumbs-o-up"></div>
+            <li class="activity-progress__item  activity-progress__item--endorsed {% if review_step > 2 %}is-completed{% endif %} grid__item width-one-fourth">
+                <div class="activity-progress__icon"></div>
                 <p class="activity-progress__label">Edits Endorsed</p>
             </li>
-            <li class="activity-progress__item {% if review_step > 3 %}is-completed{% endif %} grid__item width-one-fourth end-row">
-                <div class="activity-progress__icon fa fa-check"></div>
+            <li class="activity-progress__item activity-progress__item--published {% if review_step > 3 %}is-completed{% endif %} grid__item width-one-fourth end-row">
+                <div class="activity-progress__icon "></div>
                 <p class="activity-progress__label">Published</p>
             </li>
         </ul>
 
         {% if activity.history_summary.changes | length > 0 %}
         <div class="activity-summary row">
-            <a href="#" class="activity-summary__toggle">{{ activity.history_summary.summary }} (click to review)</a>
+            <p class="activity-overview__description">{{ activity.history_summary.summary }}</p>
             <table class="activity-summary__table">
                 <thead>
                     <tr>

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -994,7 +994,7 @@ def publish_or_destroy_activity(branch_name, action, comment_text=None):
 
         return redirect('/', code=303)
 
-def render_activities_list(task_description=None):
+def render_activities_list(task_description=None, show_new_activity_modal=False):
     ''' Render the activities list page
     '''
     repo = ChimeRepo(current_app.config['REPO_PATH'])
@@ -1029,7 +1029,7 @@ def render_activities_list(task_description=None):
     published_activities['description'] = u'activity' if published_count < 2 else u'{} activities'.format(published_count)
 
     kwargs = common_template_args(current_app.config, session)
-    kwargs.update(in_progress_activities=in_progress_activities, feedback_activities=feedback_activities, endorsed_activities=endorsed_activities, published_activities=published_activities)
+    kwargs.update(in_progress_activities=in_progress_activities, feedback_activities=feedback_activities, endorsed_activities=endorsed_activities, published_activities=published_activities, show_new_activity_modal=show_new_activity_modal)
 
     # pre-populate the new activity form with description value if it was passed
     if task_description:

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -769,8 +769,8 @@ def make_list_of_published_activities(repo, limit=10):
         date_updated = ref_split[2]
         date_created = date_updated
 
-        # the email of the person who published the activity
-        last_edited_email = ref_split[3][1:-1]
+        # the email of the person who published the activity (stripping angle brackets if they're there)
+        last_edited_email = ref_split[3].lstrip(u'<').rstrip(u'>')
 
         activity.update(date_created=date_created, date_updated=date_updated,
                         edit_path=u'#', overview_path=u'#',
@@ -1001,9 +1001,7 @@ def render_activities_list(task_description=None, show_new_activity_modal=False)
     master_name = current_app.config['default_branch']
     branch_names = [b.name for b in repo.branches if b.name != master_name]
 
-    in_progress_activities = []
-    feedback_activities = []
-    endorsed_activities = []
+    activities = dict(in_progress=[], feedback=[], endorsed=[], published=[])
 
     for branch_name in branch_names:
         safe_branch = branch_name2path(branch_name)
@@ -1016,20 +1014,16 @@ def render_activities_list(task_description=None, show_new_activity_modal=False)
 
         activity = chime_activity.ChimeActivity(repo=repo, branch_name=safe_branch, default_branch_name=current_app.config['default_branch'], actor_email=session.get('email', None))
         if activity.review_state == constants.REVIEW_STATE_FRESH or activity.review_state == constants.REVIEW_STATE_EDITED:
-            in_progress_activities.append(activity)
+            activities['in_progress'].append(activity)
         elif activity.review_state == constants.REVIEW_STATE_FEEDBACK:
-            feedback_activities.append(activity)
+            activities['feedback'].append(activity)
         elif activity.review_state == constants.REVIEW_STATE_ENDORSED:
-            endorsed_activities.append(activity)
+            activities['endorsed'].append(activity)
 
-
-    published_activities = dict(activities=make_list_of_published_activities(repo=repo, limit=10))
-    published_count = len(published_activities['activities'])
-    published_activities['count'] = published_count
-    published_activities['description'] = u'activity' if published_count < 2 else u'{} activities'.format(published_count)
+    activities['published'] = make_list_of_published_activities(repo=repo, limit=10)
 
     kwargs = common_template_args(current_app.config, session)
-    kwargs.update(in_progress_activities=in_progress_activities, feedback_activities=feedback_activities, endorsed_activities=endorsed_activities, published_activities=published_activities, show_new_activity_modal=show_new_activity_modal)
+    kwargs.update(activities=activities, show_new_activity_modal=show_new_activity_modal)
 
     # pre-populate the new activity form with description value if it was passed
     if task_description:

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -770,7 +770,7 @@ def make_list_of_published_activities(repo, limit=10):
         date_created = date_updated
 
         # the email of the person who published the activity
-        last_edited_email = ref_split[3]
+        last_edited_email = ref_split[3][1:-1]
 
         activity.update(date_created=date_created, date_updated=date_updated,
                         edit_path=u'#', overview_path=u'#',

--- a/chime/views.py
+++ b/chime/views.py
@@ -38,6 +38,22 @@ def after_request(response):
 def index():
     return view_functions.render_activities_list()
 
+@app.route('/activity', methods=['GET'])
+@log_application_errors
+@login_required
+@lock_on_user
+@synch_required
+def activity():
+    return view_functions.render_activities_list()
+
+@app.route('/start-activity', methods=['GET'])
+@log_application_errors
+@login_required
+@lock_on_user
+@synch_required
+def create_activity():
+    return view_functions.render_activities_list(show_new_activity_modal=True)
+
 @app.route('/not-allowed')
 @log_application_errors
 @browserid_hostname_required

--- a/chime/views.py
+++ b/chime/views.py
@@ -229,7 +229,7 @@ def start_branch():
     # require a task description
     if len(task_description) == 0:
         flash(u'Please describe what you\'re doing when you start a new activity!', u'warning')
-        return view_functions.render_activities_list()
+        return redirect('/activity', code=303)
 
     branch = repo_functions.get_start_branch(repo, master_name, task_description, session['email'])
     safe_branch = view_functions.branch_name2path(branch.name)

--- a/test/acceptance/test_preview.py
+++ b/test/acceptance/test_preview.py
@@ -131,11 +131,19 @@ class TestPreview(ChimeTestCase):
 
         sys.stderr.write("at url {}\n".format(main_url))
 
-        # start a new task
+        # click the start activity link to bring up the create activity form
+        self.driver.find_element_by_id("submit-start-activity").click()
+
+        # wait until we see the create task form
+        self.waiter.until(
+            EC.visibility_of_element_located((By.NAME, 'task_description'))
+        )
+
+        # fill and submit the create task form
         task_description = self.marked_string('task_description')
         self.driver.find_element_by_name('task_description').send_keys(task_description)
         main_window = self.driver.current_window_handle
-        self.driver.find_element_by_id("create-activity-button").click()
+        self.driver.find_element_by_id("submit-create-activity").click()
 
         # create a new page
         self.driver.find_element_by_id("create-category-name").send_keys(self.marked_string('category'))

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -62,7 +62,7 @@ PATTERN_FORM_CATEGORY_DESCRIPTION = u'<textarea name="en-description" class="dir
 
 # review stuff
 PATTERN_REQUEST_FEEDBACK_BUTTON = u'<button class="toolbar__item button button--orange" type="submit" name="request_feedback" value="Request Feedback">Request Feedback</button>'
-PATTERN_UNREVIEWED_EDITS_LINK = u'<a href="/tree/{branch_name}/" class="toolbar__item button">Unreviewed Edits</a>'
+PATTERN_UNREVIEWED_EDITS_LINK = u'<a href="/tree/{branch_name}/edit/">'
 PATTERN_ENDORSE_BUTTON = u'<button class="toolbar__item button button--green" type="submit" name="endorse_edits" value="Endorse Edits">Endorse Edits</button>'
 PATTERN_FEEDBACK_REQUESTED_LINK = u'<a href="/tree/{branch_name}/" class="toolbar__item button">Feedback requested</a>'
 PATTERN_PUBLISH_BUTTON = u'<button class="toolbar__item button button--blue" type="submit" name="merge" value="Publish">Publish</button>'
@@ -2001,7 +2001,7 @@ class TestApp (TestCase):
             summary_div = erica.soup.find("div", class_="activity-summary")
             self.assertIsNotNone(summary_div)
             # it's right about what's changed
-            self.assertIsNotNone(summary_div.find(lambda tag: bool(tag.name == 'a' and '2 articles and 2 topics' in tag.text)))
+            self.assertIsNotNone(summary_div.find(lambda tag: bool(tag.name == 'p' and '2 articles and 2 topics' in tag.text)))
             # grab all the table rows
             check_rows = summary_div.find_all('tr')
 
@@ -2603,7 +2603,7 @@ class TestApp (TestCase):
             # Load the front page and make sure the activity is listed as published
             #
             erica.open_link('/')
-            pub_ul = erica.soup.select('ul#published-activities')[0]
+            pub_ul = erica.soup.select('ul.activity-box--published')[0]
             # there should be an HTML comment with the branch name
             comment = pub_ul.findAll(text=lambda text: isinstance(text, Comment))[0]
             self.assertTrue(branch_name in comment)

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -420,6 +420,7 @@ class TestApp (TestCase):
             flash_message_text = u'Please describe what you\'re doing when you start a new activity!'
 
             # start a new task without a description
+            erica.open_link('/')
             erica.start_task(description=u'')
             # the activities-list template reloaded
             comments = erica.soup.findAll(text=lambda text: isinstance(text, Comment))
@@ -437,6 +438,7 @@ class TestApp (TestCase):
                 erica.sign_in(email='erica@example.com')
 
             # start a new task with a lot of random whitespace
+            erica.open_link('/')
             task_description = u'I think\n\r\n\rI am      so   \t\t\t   coool!!\n\n\nYeah.\n\nOK\n\rERWEREW      dkkdk'
             task_description_stripped = u'I think I am so coool!! Yeah. OK ERWEREW dkkdk'
             erica.start_task(description=task_description)
@@ -461,6 +463,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Lick Water Droplets From Leaves for Leopard Geckos')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -488,6 +491,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Lick Water Droplets From Leaves for Leopard Geckos')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -1184,6 +1188,7 @@ class TestApp (TestCase):
                 erica.sign_in(email='erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Be Shot Hundreds Of Feet Into The Air for A Geyser Of Highly Pressurized Water')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -1218,6 +1223,7 @@ class TestApp (TestCase):
             pattern_template_comment_stripped = sub(ur'<!--|-->', u'', PATTERN_TEMPLATE_COMMENT)
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Deep-Fry a Buffalo in Forty Seconds for Moe')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -1395,6 +1401,7 @@ class TestApp (TestCase):
                 erica.sign_in(email=erica_email)
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Ferment Tuber Fibres Using Symbiotic Bacteria in the Intestines for Naked Mole Rats')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -1557,6 +1564,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task, topic, subtopic, article
+            erica.open_link('/')
             args = 'Mermithergate for Ant Worker', 'Enoplia Nematode', 'Genus Mermis', 'Cephalotes Atratus'
             erica.quick_activity_setup(*args)
 
@@ -1997,6 +2005,7 @@ class TestApp (TestCase):
                 erica.sign_in(email='erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Parasitize with Ichneumonidae for Moth Larvae')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -2296,6 +2305,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Take Malarone for People Susceptible to Malaria')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -2321,6 +2331,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Chew Mulberry Leaves for Silkworms')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -2497,6 +2508,7 @@ class TestApp (TestCase):
                 erica.sign_in('erica@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description=u'Be Shot Hundreds Of Feet Into The Air for A Geyser Of Highly Pressurized Water')
             # Get the branch name
             branch_name = erica.get_branch_name()
@@ -2525,6 +2537,7 @@ class TestApp (TestCase):
                 frances.sign_in('frances@example.com')
             
             # Start a new task, "Diving for Dollars".
+            frances.open_link('/')
             frances.start_task(description=u'Diving for Dollars')
             branch_name = frances.get_branch_name()
             
@@ -2558,6 +2571,7 @@ class TestApp (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            frances.open_link('/')
             frances.start_task(description=u'Crunching Beetles for Trap-Door Spiders')
             branch_name = frances.get_branch_name()
 
@@ -2582,6 +2596,7 @@ class TestApp (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            frances.open_link('/')
             frances.start_task(description=u'Beating Crunches for Door-Spider Traps')
 
             # hit the front page a bunch of times
@@ -2616,6 +2631,7 @@ class TestApp (TestCase):
                 frances.sign_in(frances_email)
 
             # Start a new task and create a topic, subtopic and article
+            erica.open_link('/')
             activity_title = u'Flicking Ants Off My Laptop'
             args = activity_title, u'Flying', u'Through The Air', u'Goodbye'
             branch_name = erica.quick_activity_setup(*args)

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -707,8 +707,20 @@ class TestApp (TestCase):
             # get the activity list page
             response = self.test_client.get('/', follow_redirects=True)
             self.assertEqual(response.status_code, 200)
-            # verify that there's an unreviewed edits link
-            self.assertTrue(PATTERN_UNREVIEWED_EDITS_LINK.format(branch_name=generated_branch_name) in response.data)
+            # verify that the project is listed in the edited column
+            soup = BeautifulSoup(response.data)
+            pub_ul = soup.select("#activity-list-edited")[0]
+            # there should be an HTML comment with the branch name
+            comments = pub_ul.findAll(text=lambda text: isinstance(text, Comment))
+            found = False
+            for comment in comments:
+                if generated_branch_name in comment:
+                    found = True
+                    pub_li = comment.find_parent('li')
+                    # and the activity title wrapped in an a tag
+                    self.assertIsNotNone(pub_li.find('a', text=fake_task_description))
+
+            self.assertEqual(True, found)
 
         # Request feedback on the change
         with HTTMock(self.auth_csv_example_allowed):

--- a/test/unit/chime_test_client.py
+++ b/test/unit/chime_test_client.py
@@ -110,8 +110,8 @@ class ChimeTestClient:
     def delete_task(self, branch_name):
         ''' Look for button to delete a task, click it.
         '''
-        hidden = self.soup.find(lambda tag: bool(tag.name == 'input' and tag.get('value') == branch_name))
-        form = hidden.find_parent('form')
+        button = self.soup.select('#{}-delete'.format(branch_name))[0]
+        form = button.find_parent('form')
 
         self.test.assertEqual(form['method'].upper(), 'POST')
 
@@ -120,7 +120,6 @@ class ChimeTestClient:
 
         delete_task_path = urlparse(urljoin(self.path, form['action'])).path
         response = self.client.post(delete_task_path, data=data)
-
         self.follow_redirect(response, 303)
 
     def add_category(self, category_name):

--- a/test/unit/chime_test_client.py
+++ b/test/unit/chime_test_client.py
@@ -97,11 +97,30 @@ class ChimeTestClient:
         return branch_name
 
     def start_task(self, description):
-        ''' Start a new task.
+        ''' Look for form to start a task, submit it.
         '''
-        data = {'task_description': description}
-        response = self.client.post('/start', data=data)
+        # verify we're on a page that has a start activity link
+        start_link = self.soup.find(id='submit-start-activity')
+        self.test.assertIsNotNone(start_link, u'No start link on current page')
 
+        # if the modal container's not open, click the start activity link
+        if not self.soup.find('div', 'modal-container', 'is-open'):
+            self.open_link(start_link['href'])
+
+        # verify that the modal container is now open
+        self.test.assertIsNotNone(self.soup.find('div', 'modal-container', 'is-open'), u'No open modal container when expected')
+
+        # find the create task form and submit it
+        button = self.soup.find(id='submit-create-activity')
+        self.test.assertIsNotNone(button)
+        form = button.find_parent('form')
+        self.test.assertEqual(form['method'].upper(), 'POST')
+
+        data = {i['name']: i.get('value', u'') for i in form.find_all(['input', 'button', 'textarea']) if i.has_attr('name')}
+        data['task_description'] = description
+
+        start_task_path = urlparse(urljoin(self.path, form['action'])).path
+        response = self.client.post(start_task_path, data=data)
         if response.status_code == 200:
             self.soup, self.headers = BeautifulSoup(response.data), response.headers
         else:

--- a/test/unit/process.py
+++ b/test/unit/process.py
@@ -144,9 +144,9 @@ class TestProcess (TestCase):
             with HTTMock(self.mock_persona_verify_frances):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in('frances@example.com')
-            
-            # Start a new task, "Diving for Dollars", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+
+            # Start a new task
+            erica.open_link('/')
             args = 'Diving for Dollars', 'Ninjas', 'Flipping Out', 'So Awesome'
             branch_name = erica.quick_activity_setup(*args)
             
@@ -186,6 +186,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
             
             # Erica starts a new task, "Diving for Dollars".
+            erica.open_link('/')
             erica.start_task('Diving for Dollars')
             erica_branchname = erica.get_branch_name()
             
@@ -196,6 +197,7 @@ class TestProcess (TestCase):
             erica.request_feedback('Is this okay?')
             
             # Frances starts a new task, "Bobbing for Apples".
+            frances.open_link('/')
             frances.start_task('Bobbing for Apples')
             frances_branchname = frances.get_branch_name()
             
@@ -210,6 +212,7 @@ class TestProcess (TestCase):
             frances.publish_activity()
             
             # Erica should now expect to see her own new category.
+            erica.open_link('/')
             erica.start_task('Canticle for Leibowitz')
             erica_branchname2 = erica.get_branch_name()
             erica.follow_link('/tree/{}/edit/other/'.format(erica_branchname2))
@@ -235,8 +238,8 @@ class TestProcess (TestCase):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in(frances_email)
 
-            # Start a new task, "Diving for Dollars", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            erica.open_link('/')
             args = 'Diving for Dollars', 'Ninjas', 'Flipping Out', 'So Awesome'
             branch_name = erica.quick_activity_setup(*args)
 
@@ -282,14 +285,14 @@ class TestProcess (TestCase):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in('frances@example.com')
 
-            # Start a new task, "Bobbing for Apples", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            frances.open_link('/')
             args = 'Bobbing for Apples', 'Ninjas', 'Flipping Out', 'So Awesome'
             f_branch_name = frances.quick_activity_setup(*args)
             f_article_path = frances.path
 
-            # Start a new task, "Diving for Dollars", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            erica.open_link('/')
             args = 'Diving for Dollars', 'Ninjas', 'Flipping Out', 'So Awesome'
             e_branch_name = erica.quick_activity_setup(*args)
 
@@ -334,13 +337,13 @@ class TestProcess (TestCase):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in('frances@example.com')
 
-            # Frances: Start a new task, "Bobbing for Apples", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Frances: Start a new task
+            frances.open_link('/')
             args = 'Bobbing for Apples', 'Ninjas', 'Flipping Out', 'So Awesome'
             frances.quick_activity_setup(*args)
 
-            # Erica: Start a new task, "Diving for Dollars", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Erica: Start a new task
+            erica.open_link('/')
             args = 'Diving for Dollars', 'Ninjas', 'Flipping Out', 'So Awesome'
             erica.quick_activity_setup(*args)
 
@@ -362,14 +365,14 @@ class TestProcess (TestCase):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in('frances@example.com')
 
-            # Start a new task, "Bobbing for Apples", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            frances.open_link('/')
             args = 'Bobbing for Apples', 'Ninjas', 'Flipping Out', 'So Awesome'
             f_branch_name = frances.quick_activity_setup(*args)
             f_article_path = frances.path
 
-            # Start a new task, "Diving for Dollars", create a new category
-            # "Samurai", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            erica.open_link('/')
             args = 'Diving for Dollars', 'Samurai', 'Flipping Out', 'So Awesome'
             e_branch_name = erica.quick_activity_setup(*args)
 
@@ -417,6 +420,7 @@ class TestProcess (TestCase):
                 frances.sign_in(frances_email)
 
             # Frances: Start a new task, topic, subtopic, article
+            frances.open_link('/')
             args = 'Triassic for Artemia', 'Biological', 'Toxicity', 'Assays'
             frances.quick_activity_setup(*args)
             branch_name = frances.get_branch_name()
@@ -456,6 +460,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description='Eating Carrion for Vultures')
             erica_branch_name = erica.get_branch_name()
 
@@ -478,6 +483,7 @@ class TestProcess (TestCase):
             # Switch users
             #
             # Start a new task
+            frances.open_link('/')
             frances.start_task(description='Flying in Circles for Vultures')
             frances_branch_name = frances.get_branch_name()
 
@@ -536,6 +542,7 @@ class TestProcess (TestCase):
                 frances.sign_in(frances_email)
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description='Eating Carrion for Vultures')
             erica_branch_name = erica.get_branch_name()
 
@@ -588,6 +595,7 @@ class TestProcess (TestCase):
                 frances.sign_in(frances_email)
 
             # Start a new task
+            erica.open_link('/')
             erica.start_task(description='Eating Carrion for Vultures')
             erica_branch_name = erica.get_branch_name()
 
@@ -651,6 +659,7 @@ class TestProcess (TestCase):
                 frances.sign_in(frances_email)
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Squeeze A School Of Fish Into A Bait Ball for Dolphins'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -720,6 +729,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Eating Carrion for Vultures'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -757,6 +767,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Eating Carrion for Vultures'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -804,6 +815,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Squeeze A School Of Fish Into A Bait Ball for Dolphins'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -867,6 +879,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Eating Carrion for Vultures'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -942,6 +955,7 @@ class TestProcess (TestCase):
                 frances.sign_in('frances@example.com')
 
             # Start a new task
+            erica.open_link('/')
             task_description = u'Eating Carrion for Vultures'
             erica.start_task(description=task_description)
             erica_branch_name = erica.get_branch_name()
@@ -1021,8 +1035,8 @@ class TestProcess (TestCase):
                 frances = ChimeTestClient(self.app.test_client(), self)
                 frances.sign_in('frances@example.com')
 
-            # Start a new task, "Bobbing for Apples", create a new category
-            # "Ninjas", subcategory "Flipping Out", and article "So Awesome".
+            # Start a new task
+            frances.open_link('/')
             args = 'Bobbing for Apples', 'Ninjas', 'Flipping Out', 'So Awesome'
             frances.quick_activity_setup(*args)
             frances.edit_article(title_str='So, So Awesome', body_str='It was the best of times.')


### PR DESCRIPTION
This pull request changes the layout of the activity dashboard view to:

1. Group activities by state so its easier to see what work is going on across the site and makes activity cards smaller so you can see more activities at once.

2. Add an activity action toolbar to each activity card so you can easily jump to either the content or the overview page.

3. Changes the link in the activity title to go to the overview page instead (allows us to not have an activity toolbar in the published activities and also it makes more sense for clicking on an activity to jump you the overview of the activity)

4. Puts the activity creation in a modal (better fits the interface and provides a space where we can provide a more in depth description of what an activity is)

@tmaybe can you review this?

![screen shot 2015-09-17 at 2 26 14 pm](https://cloud.githubusercontent.com/assets/606439/9946430/12c26426-5d48-11e5-94d9-396c9b65b5c5.png)
