### PR TITLE
Show published activities overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ repo-*
 ga_config.json
 .idea
 *.iml
+*.lock
 apache
 *.lock
 

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -133,8 +133,8 @@ class ChimeActivity:
         for action in edit_history:
             # get the list of changed files from the commit body
             commit_body = action['commit_body']
-            # don't continue if the commit body's not a dict
-            if type(commit_body) is not dict:
+            # don't continue if the commit body's not a dict or list
+            if type(commit_body) is not dict and type(commit_body) is not list:
                 continue
 
             # step through the changed files

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -132,7 +132,9 @@ class ChimeActivity:
                 continue
 
             # step through the changed files
-            for file_change in commit_body:
+            # NOTE: don't break if this is an old-style commit message
+            actions = commit_body['actions'] if 'actions' in commit_body else commit_body
+            for file_change in actions:
                 # the passed title or the filename if no title is there
                 title = file_change['title'] or file_change['file_path'].split('/')[-1]
                 # the passed display type or Unknown if no type is there

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -173,8 +173,8 @@ class ChimeActivity:
             summary_sentence_parts = []
             display_type_tally = Counter(display_types_encountered)
             display_lookup = (
-                (display_type_tally[constants.ARTICLE_LAYOUT.title()], unicode(constants.ARTICLE_LAYOUT), unicode(constants.LAYOUT_PLURAL_LOOKUP[constants.ARTICLE_LAYOUT])),
-                (display_type_tally[constants.CATEGORY_LAYOUT.title()], unicode(constants.CATEGORY_LAYOUT), unicode(constants.LAYOUT_PLURAL_LOOKUP[constants.CATEGORY_LAYOUT]))
+                (display_type_tally[constants.ARTICLE_LAYOUT.title()], unicode(constants.LAYOUT_DISPLAY_LOOKUP[constants.ARTICLE_LAYOUT]), unicode(constants.LAYOUT_PLURAL_LOOKUP[constants.ARTICLE_LAYOUT])),
+                (display_type_tally[constants.CATEGORY_LAYOUT.title()], unicode(constants.LAYOUT_DISPLAY_LOOKUP[constants.CATEGORY_LAYOUT]), unicode(constants.LAYOUT_PLURAL_LOOKUP[constants.CATEGORY_LAYOUT]))
             )
             for tally, singular, plural in display_lookup:
                 if tally:

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -136,12 +136,17 @@ class ChimeActivity:
                 # the passed title or the filename if no title is there
                 title = file_change['title'] or file_change['file_path'].split('/')[-1]
                 # the passed display type or Unknown if no type is there
-                display_type = file_change['display_type'].title() or u'Unknown'
+                display_type = file_change['display_type'] or u'unknown'
+                # how to represent the display type in the interface (i.e. Category -> Topic)
+                show_type = constants.LAYOUT_DISPLAY_LOOKUP[display_type] if display_type in constants.LAYOUT_DISPLAY_LOOKUP else display_type
+                display_type = display_type.title()
+                show_type = show_type.title()
                 try:
                     action = ed_lookup[file_change['action']].title()
                 except:
                     action = file_change['action'].title()
                 file_path = file_change['file_path']
+
                 # if the last action is delete, we don't want an edit_path to a file that no longer exists
                 edit_path = join(u'/tree/{}/edit/'.format(self.safe_branch), repo_functions.strip_index_file(file_path)) if action != u'Deleted' else u''
                 sort_time = datetime.now()
@@ -153,9 +158,9 @@ class ChimeActivity:
                     # add the other variables, which may've changed
                     change_lookup[file_path]['edit_path'] = edit_path
                     change_lookup[file_path]['title'] = title
-                    change_lookup[file_path]['display_type'] = display_type
+                    change_lookup[file_path]['display_type'] = show_type
                 else:
-                    change_lookup[file_path] = dict(title=title, display_type=display_type, actions=action, edit_path=edit_path, sort_time=sort_time)
+                    change_lookup[file_path] = dict(title=title, display_type=show_type, actions=action, edit_path=edit_path, sort_time=sort_time)
                     display_types_encountered.append(display_type)
 
         # flatten and sort the changes

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -203,7 +203,7 @@ class ChimePublishedActivity(ChimeActivity):
         self.author_email, self.task_description = self._process_task_metadata(task_metadata)
 
         # we know the current review state and authorized status
-        self.review_state = constants.WORKING_STATE_PUBLISHED
+        self.review_state = constants.REVIEW_STATE_PUBLISHED
         self.review_authorized = False
 
         # get date updated and last edited email from the tag's git log

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -71,19 +71,17 @@ class ChimeActivity:
 
         return self._working_state
 
-    def _get_history_log(self, log_format, hexsha):
+    def _get_history_log(self, log_format):
         ''' Get a git log from which to create the activity's history
         '''
+        hexsha = self.repo.branches[self.safe_branch].commit.hexsha
         return self.repo.git.log('--format={}'.format(log_format), '--date=relative', 'master..{}'.format(hexsha))
 
     def _make_history(self):
         ''' Make an easily-parsable history of the activity since it was created.
         '''
         # see <http://git-scm.com/docs/git-log> for placeholders
-        log = self._get_history_log(
-            log_format='%x00Name: %an\tEmail: %ae\tDate: %ad\tSubject: %s\tBody: %b%x00',
-            hexsha=self.repo.branches[self.safe_branch].commit.hexsha
-        )
+        log = self._get_history_log(log_format='%x00Name: %an\tEmail: %ae\tDate: %ad\tSubject: %s\tBody: %b%x00')
 
         history = []
         pattern = re.compile(r'\x00Name: (.*?)\tEmail: (.*?)\tDate: (.*?)\tSubject: (.*?)\tBody: (.*?)\x00', re.DOTALL)
@@ -225,7 +223,8 @@ class ChimePublishedActivity(ChimeActivity):
         self._history_summary = None
         self._working_state = None
 
-    def _get_history_log(self, log_format, hexsha):
+    def _get_history_log(self, log_format):
         ''' Get a git log from which to create the activity's history
         '''
-        return self.repo.git.log('--format={}'.format(log_format), '--date=relative', 'master..{}'.format(hexsha))
+        hexsha = self.repo.tags[self.safe_branch].commit.hexsha
+        return self.repo.git.log('--format={}'.format(log_format), '--date=relative', hexsha)

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -254,8 +254,13 @@ class ChimePublishedActivity(ChimeActivity):
         edited_history = []
         # crop the history to the beginning of this published activity
         for log_item in full_history:
-            edited_history.append(log_item)
-            if log_item['commit_type'] == constants.COMMIT_TYPE_ACTIVITY_UPDATE and log_item['commit_subject'] == u'The "{}" {}'.format(self.task_description, repo_functions.ACTIVITY_CREATED_MESSAGE):
-                break
+            # filter by branch name, if it's there
+            commit_body = log_item['commit_body']
+            has_branch_name = type(commit_body) is dict and 'branch_name' in commit_body
+            is_eligible = has_branch_name and commit_body['branch_name'] == self.safe_branch
+            if is_eligible or not has_branch_name:
+                edited_history.append(log_item)
+                if log_item['commit_type'] == constants.COMMIT_TYPE_ACTIVITY_UPDATE and log_item['commit_subject'] == u'The "{}" {}'.format(self.task_description, repo_functions.ACTIVITY_CREATED_MESSAGE):
+                    break
 
         return edited_history

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -180,12 +180,6 @@ class ChimeActivity:
         '''
         author_email = task_metadata['author_email'] if 'author_email' in task_metadata else u''
         task_description = task_metadata['task_description'] if 'task_description' in task_metadata else self.safe_branch
-        # add the beneficiary to the description if it's there
-        try:
-            task_description = u'{} for {}'.format(task_description, task_metadata['task_beneficiary'])
-        except KeyError:
-            pass
-
         return author_email, task_description
 
 

--- a/chime/chime_activity.py
+++ b/chime/chime_activity.py
@@ -258,6 +258,7 @@ class ChimePublishedActivity(ChimeActivity):
             commit_body = log_item['commit_body']
             has_branch_name = type(commit_body) is dict and 'branch_name' in commit_body
             is_eligible = has_branch_name and commit_body['branch_name'] == self.safe_branch
+            # include it if it doesn't have a branch name, for backwards-compatibility
             if is_eligible or not has_branch_name:
                 edited_history.append(log_item)
                 if log_item['commit_type'] == constants.COMMIT_TYPE_ACTIVITY_UPDATE and log_item['commit_subject'] == u'The "{}" {}'.format(self.task_description, repo_functions.ACTIVITY_CREATED_MESSAGE):

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -474,7 +474,7 @@ def clobber_default_branch(clone, default_branch_name, working_branch_name, comm
     clone.remotes.origin.push(':' + working_branch_name)
     clone.delete_head([working_branch_name])
 
-def sync_with_default_and_upstream_branches(clone, sync_branch_name):
+def sync_with_branch(clone, working_branch_name, sync_branch_name):
     ''' Sync the passed branch with default and upstream branches.
     '''
     msg = 'Merged work from "%s"' % sync_branch_name
@@ -527,7 +527,7 @@ def save_working_file(clone, path, message, base_sha, default_branch_name):
     #
     for sync_branch_name in (active_branch_name, ):
         try:
-            sync_with_default_and_upstream_branches(clone, sync_branch_name)
+            sync_with_branch(clone, active_branch_name, sync_branch_name)
         except MergeConflict as conflict:
             raise conflict
 
@@ -611,7 +611,7 @@ def move_existing_file(clone, old_path, new_path, base_sha, default_branch_name)
     #
     for sync_branch_name in (active_branch_name, default_branch_name):
         try:
-            sync_with_default_and_upstream_branches(clone, sync_branch_name)
+            sync_with_branch(clone, active_branch_name, sync_branch_name)
         except MergeConflict as conflict:
             raise conflict
 
@@ -767,7 +767,7 @@ def add_empty_commit(clone, subject, body, push=True):
     #
     for sync_branch_name in (active_branch_name, ):
         try:
-            sync_with_default_and_upstream_branches(clone, sync_branch_name)
+            sync_with_branch(clone, active_branch_name, sync_branch_name)
         except MergeConflict as conflict:
             raise conflict
 

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -479,11 +479,11 @@ def sync_with_branch(clone, working_branch_name, sync_branch_name):
     ''' Sync the passed branch with default and upstream branches.
     '''
     clone.git.fetch('origin', sync_branch_name)
+    branch_name = working_branch_name if working_branch_name else clone.active_branch.name
+    message_body = dict(branch_name=branch_name, sync_branch_name=sync_branch_name, message=ACTIVITY_MERGED_MESSAGE)
+    message = make_commit_message(subject=ACTIVITY_MERGED_MESSAGE, body=json.dumps(message_body, ensure_ascii=False))
 
     try:
-        branch_name = working_branch_name if working_branch_name else clone.active_branch.name
-        message_body = dict(branch_name=branch_name, sync_branch_name=sync_branch_name, message=ACTIVITY_MERGED_MESSAGE)
-        message = make_commit_message(subject=ACTIVITY_MERGED_MESSAGE, body=json.dumps(message_body, ensure_ascii=False))
         clone.git.merge('FETCH_HEAD', '--no-ff', m=message)
 
     except GitCommandError:

--- a/chime/repo_functions.py
+++ b/chime/repo_functions.py
@@ -239,9 +239,9 @@ def save_task_metadata_for_branch(clone, default_branch_name, values={}):
     # craft the commit message
     task_metadata_json = json.dumps(task_metadata, ensure_ascii=False)
     if check_metadata == {}:
-        message = u'The "{}" {}\n\n{}'.format(task_metadata['task_description'], ACTIVITY_CREATED_MESSAGE, task_metadata_json)
+        message = make_commit_message(subject=u'The "{}" {}'.format(task_metadata['task_description'], ACTIVITY_CREATED_MESSAGE), body=task_metadata_json)
     else:
-        message = u'The "{}" {}\n\n{}'.format(task_metadata['task_description'], ACTIVITY_UPDATED_MESSAGE, task_metadata_json)
+        message = make_commit_message(subject=u'The "{}" {}'.format(task_metadata['task_description'], ACTIVITY_UPDATED_MESSAGE), body=task_metadata_json)
 
     # Dump the updated task metadata to disk
     # Use newline-preserving block literal form.
@@ -267,7 +267,7 @@ def delete_task_metadata_for_branch(clone, default_branch_name):
     message = u''
     if do_save:
         task_metadata_json = json.dumps(task_metadata, ensure_ascii=False)
-        message = u'The "{}" {}\n\n{}'.format(task_metadata['task_description'], ACTIVITY_DELETED_MESSAGE, task_metadata_json)
+        message = make_commit_message(subject=u'The "{}" {}'.format(task_metadata['task_description'], ACTIVITY_DELETED_MESSAGE), body=task_metadata_json)
         save_working_file(clone, TASK_METADATA_FILENAME, message, clone.commit().hexsha, default_branch_name)
     return task_metadata, message
 

--- a/chime/templates/activity-overview.html
+++ b/chime/templates/activity-overview.html
@@ -134,12 +134,12 @@
                 {% if log_item.commit_type == config.COMMIT_TYPE_COMMENT %}
                 <div class="comment">
                     <div class="comment__author">{{ log_item.author_email }}</div>
-                    <div class="comment__body">{{ log_item.commit_body }}</div>
+                    <div class="comment__body">{{ log_item.message }}</div>
                     <div class="comment__datetime">{{ log_item.commit_date }}</div>
                 </div>
                 {% elif log_item.commit_type == config.COMMIT_TYPE_REVIEW_UPDATE %}
                 <div class="activity-log-item__content">
-                    <p class="text-{% if log_item.commit_action == config.REVIEW_STATE_FEEDBACK %}orange{% elif log_item.commit_action == config.REVIEW_STATE_ENDORSED %}green{% else %}blue{% endif %}">{{ log_item.author_email }} {{ log_item.commit_body }}</p>
+                    <p class="text-{% if log_item.commit_action == config.REVIEW_STATE_FEEDBACK %}orange{% elif log_item.commit_action == config.REVIEW_STATE_ENDORSED %}green{% else %}blue{% endif %}">{{ log_item.author_email }} {{ log_item.message }}</p>
                     <div class="activity-log-item__datetime">{{ log_item.commit_date }}</div>
                 </div>
                 {% else %}

--- a/chime/templates/activity-overview.html
+++ b/chime/templates/activity-overview.html
@@ -102,7 +102,7 @@
 
             {% if activity.working_state == config.WORKING_STATE_ACTIVE %}
             <p class="activity-overview__description"><a href="{{ activity.edit_path }}">Do more work on this activity</a> or {{ comment_note }}.</p>
-            {% else %}
+            {% elif activity.edit_path %}
             <p class="activity-overview__description"><a href="{{ activity.edit_path }}">Browse this activity.</a></p>
             {% endif %}
 

--- a/chime/templates/activity-overview.html
+++ b/chime/templates/activity-overview.html
@@ -144,7 +144,11 @@
                 </div>
                 {% else %}
                 <div class="activity-log-item__content">
+                    {% if log_item.message %}
+                    <p>{{ log_item.message }}</p>
+                    {% else %}
                     <p>{{ log_item.commit_subject }} by {{ log_item.author_email }}.</p>
+                    {% endif %}
                     <div class="activity-log-item__datetime">{{ log_item.commit_date }}</div>
                 </div>
                 {% endif %}

--- a/chime/templates/base.html
+++ b/chime/templates/base.html
@@ -20,7 +20,7 @@
         <title>{% block title %}{% endblock %} | Chime</title>
         <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
         {% if activity %}
-        <!-- branch: {{branch}} -->
+        <!-- branch: {{ safe_branch }} -->
         <!-- author: {% if activity.author_email %}{{activity.author_email}}{% else %}unknown{% endif %} -->
         {% endif %}
         <script>
@@ -38,7 +38,7 @@
 
     {% block global_header %}
       {% from 'macros/macros.html' import globalHeader as globalHeader %}
-      {{ globalHeader(breadcrumb_items = breadcrumb_items, email=email, branch=branch, activity=activity, live_site_url=live_site_url) }}
+      {{ globalHeader(breadcrumb_items=breadcrumb_items, email=email, branch_name=safe_branch, activity=activity, live_site_url=live_site_url) }}
     {% endblock %}
 
     {% include 'includes/flashes.html' %}

--- a/chime/templates/macros/macros.html
+++ b/chime/templates/macros/macros.html
@@ -1,4 +1,4 @@
-{% macro globalHeader(breadcrumb_items=[], email, branch, activity, live_site_url) -%}
+{% macro globalHeader(breadcrumb_items=[], email, branch_name, activity, live_site_url) -%}
 <div class="global-header  row">
   <div class="row__left">
     <a href="/" class="global-header__title">Chime</a>
@@ -12,13 +12,13 @@
     {% if config.get('DEBUG') %}
     <span class="toolbar__item global-header__link">&#x1f525; DEBUG MODE IS ON &#x1f525;</span>
     {% endif %}
-    {% if branch %}
+    {% if branch_name %}
     <div class="dropdown activity-dropdown toolbar__item global-header__link">
-      <a href="/tree/{{ branch }}" class="dropdown__label activity-dropdown__link">{{ activity.task_description | title }}</a>
+      <a href="/tree/{{ branch_name }}" class="dropdown__label activity-dropdown__link">{{ activity.task_description | title }}</a>
       <div class="dropdown__popup dropdown__popup--right">
         <p class="activity-dropdown__subtitle">Current Activity</p>
         <h2 class="activity-dropdown__title">{{ activity.task_description | title }}</h2>
-        <a class="button button--green button--large activity-dropdown__button" href="/tree/{{branch}}">See full history and discussion</a>
+        <a class="button button--green button--large activity-dropdown__button" href="/tree/{{ branch_name }}">See full history and discussion</a>
         {% if activity.review_state != config.REVIEW_STATE_PUBLISHED and activity.working_state == config.WORKING_STATE_ACTIVE %}
         <form action="{{ activity.overview_path }}" method="POST" class="comment comment--new">
           <div class="comment__author">{% if email %}{{ email }}{% else %}unknown{% endif %}</div>

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -896,14 +896,14 @@ def update_activity_review_state(safe_branch, comment_text, action_list, redirec
         else:
             # comment if comment text was sent and the action is authorized
             if comment_text:
-                provide_feedback(clone=repo, comment_text=comment_text, push=True)
+                provide_feedback(clone=repo, working_branch_name=safe_branch, comment_text=comment_text, push=True)
 
             # handle a review action
             if action != 'comment':
                 if action == 'request_feedback':
-                    update_review_state(clone=repo, new_review_state=current_app.config['REVIEW_STATE_FEEDBACK'], push=True)
+                    update_review_state(clone=repo, working_branch_name=safe_branch, new_review_state=current_app.config['REVIEW_STATE_FEEDBACK'], push=True)
                 elif action == 'endorse_edits':
-                    update_review_state(clone=repo, new_review_state=current_app.config['REVIEW_STATE_ENDORSED'], push=True)
+                    update_review_state(clone=repo, working_branch_name=safe_branch, new_review_state=current_app.config['REVIEW_STATE_ENDORSED'], push=True)
             elif not comment_text:
                 flash(u'You can\'t leave an empty comment!', u'warning')
 
@@ -1003,7 +1003,7 @@ def render_activities_list(task_description=None, show_new_activity_modal=False)
 def make_kwargs_for_activity_files_page(repo, branch_name, path):
     ''' Assemble the kwargs for a page that shows an activity's files.
     '''
-    # :NOTE: temporarily turning off filtering if 'showallfiles=true' is in the request
+    # NOTE: temporarily turning off filtering if 'showallfiles=true' is in the request
     showallfiles = request.args.get('showallfiles') == u'true'
 
     activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name=current_app.config['default_branch'], actor_email=session.get('email', None))

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -39,7 +39,7 @@ from .repo_functions import (
     clobber_default_branch, get_review_state_and_authorized, update_review_state,
     provide_feedback, move_existing_file, mark_upstream_push_needed, MergeConflict,
     get_activity_working_state, make_branch_name, save_local_working_file,
-    sync_with_branch, strip_index_file
+    sync_with_branch, strip_index_file, make_commit_message
 )
 from . import constants
 
@@ -721,9 +721,8 @@ def make_delete_display_commit_message(repo, working_branch_name, request_path):
         action_descriptions.append(file_description)
     branch_name = working_branch_name if working_branch_name else repo.active_branch.name
     message_body = dict(branch_name=branch_name, actions=action_descriptions)
-    commit_message = commit_message + u'\n\n' + json.dumps(message_body, ensure_ascii=False)
 
-    return commit_message
+    return make_commit_message(subject=commit_message, body=json.dumps(message_body, ensure_ascii=False))
 
 def make_list_of_published_activities(repo, limit=10):
     ''' Make a list of recently published activities.
@@ -1108,7 +1107,7 @@ def add_article_or_category(repo, working_branch_name, dir_path, request_path, c
     action_descriptions = [{'action': u'create', 'title': display_name, 'display_type': create_what, 'file_path': file_path}]
     branch_name = working_branch_name if working_branch_name else repo.active_branch.name
     message_body = dict(branch_name=branch_name, actions=action_descriptions)
-    commit_message = u'The "{}" {} was created\n\n{}'.format(display_name, display_what, json.dumps(message_body, ensure_ascii=False))
+    commit_message = make_commit_message(subject=u'The "{}" {} was created'.format(display_name, display_what), body=json.dumps(message_body, ensure_ascii=False))
 
     return commit_message, file_path, redirect_path, True
 
@@ -1262,7 +1261,7 @@ def save_page(repo, default_branch_name, working_branch_name, file_path, new_val
     action_descriptions = [{'action': u'edit', 'title': display_name, 'display_type': display_type, 'file_path': file_path}]
     branch_name = working_branch_name if working_branch_name else repo.active_branch.name
     message_body = dict(branch_name=branch_name, actions=action_descriptions)
-    commit_message = u'The "{}" {} was edited\n\n{}'.format(display_name, display_type, json.dumps(message_body, ensure_ascii=False))
+    commit_message = make_commit_message(subject=u'The "{}" {} was edited'.format(display_name, display_type), body=json.dumps(message_body, ensure_ascii=False))
     c2 = save_local_working_file(repo, file_path, commit_message)
 
     if possible_conflict:

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -631,10 +631,6 @@ def synched_checkout_required(route_function):
             published_by = commit.committer.email
             flash_only(MESSAGE_ACTIVITY_PUBLISHED.format(published_date=published_date, published_by=published_by), u'warning')
 
-            # if the published branch doesn't exist locally, raise a 404
-            if not local_branch:
-                abort(404)
-
         elif working_state == constants.WORKING_STATE_DELETED:
             flash_only(MESSAGE_ACTIVITY_DELETED, u'warning')
 

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -750,33 +750,19 @@ def make_list_of_published_activities(repo, limit=10):
         # if there's no parsable task metadata in the tag's subject, this isn't a viable published activity
         try:
             # contains 'author_email', 'task_description'
-            activity = json.loads(ref_split[1])
+            task_metadata = json.loads(ref_split[1])
         except ValueError:
             continue
-        activity['author_email'] = activity['author_email'] if 'author_email' in activity else u''
-        activity['task_description'] = activity['task_description'] if 'task_description' in activity else safe_branch
-        # add the beneficiary to the description if it's there
-        try:
-            activity['task_description'] = u'{} for {}'.format(activity['task_description'], activity['task_beneficiary'])
-        except KeyError:
-            pass
 
-        # we know the current review state and authorized status
-        review_state = constants.WORKING_STATE_PUBLISHED
-        review_authorized = False
-
-        # set date created and updated the same for now
         date_updated = ref_split[2]
-        date_created = date_updated
-
         # the email of the person who published the activity (stripping angle brackets if they're there)
         last_edited_email = ref_split[3].lstrip(u'<').rstrip(u'>')
 
-        activity.update(date_created=date_created, date_updated=date_updated,
-                        edit_path=u'#', overview_path=u'#',
-                        safe_branch=safe_branch, review_state=review_state,
-                        review_authorized=review_authorized, last_edited_email=last_edited_email)
-
+        # create a new ChimePublishedActivity and append it to published
+        activity = chime_activity.ChimePublishedActivity(
+            repo=repo, branch_name=safe_branch, default_branch_name=current_app.config['default_branch'],
+            task_metadata=task_metadata, date_updated=date_updated, last_edited_email=last_edited_email
+        )
         published.append(activity)
 
     return published

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -1261,7 +1261,7 @@ def save_page(repo, default_branch_name, working_branch_name, file_path, new_val
     action_descriptions = [{'action': u'edit', 'title': display_name, 'display_type': display_type, 'file_path': file_path}]
     branch_name = working_branch_name if working_branch_name else repo.active_branch.name
     message_body = dict(branch_name=branch_name, actions=action_descriptions)
-    commit_message = make_commit_message(subject=u'The "{}" {} was edited'.format(display_name, display_type), body=json.dumps(message_body, ensure_ascii=False))
+    commit_message = make_commit_message(subject=u'The "{}" {} was edited'.format(display_name, file_display_name(display_type)), body=json.dumps(message_body, ensure_ascii=False))
     c2 = save_local_working_file(repo, file_path, commit_message)
 
     if possible_conflict:

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -1007,7 +1007,7 @@ def make_kwargs_for_activity_files_page(repo, branch_name, path):
     activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name=current_app.config['default_branch'], actor_email=session.get('email', None))
 
     kwargs = common_template_args(current_app.config, session)
-    kwargs.update(branch=branch_name, safe_branch=branch_name2path(branch_name),
+    kwargs.update(safe_branch=branch_name2path(branch_name),
                   breadcrumb_paths=make_breadcrumb_paths(branch_name, path),
                   dir_columns=make_directory_columns(repo, branch_name, path, showallfiles),
                   activity=activity)
@@ -1068,7 +1068,7 @@ def render_edit_view(repo, branch_name, path, file):
     activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name=current_app.config['default_branch'], actor_email=session.get('email', None))
 
     kwargs = common_template_args(current_app.config, session)
-    kwargs.update(branch=branch_name, safe_branch=branch_name2path(branch_name),
+    kwargs.update(safe_branch=branch_name2path(branch_name),
                   body=body, hexsha=commit.hexsha, url_slug=url_slug,
                   front=front, view_path=view_path, edit_path=path,
                   history_path=history_path, save_path=save_path, languages=languages,

--- a/chime/view_functions.py
+++ b/chime/view_functions.py
@@ -39,7 +39,7 @@ from .repo_functions import (
     clobber_default_branch, get_review_state_and_authorized, update_review_state,
     provide_feedback, move_existing_file, mark_upstream_push_needed, MergeConflict,
     get_activity_working_state, make_branch_name, save_local_working_file,
-    sync_with_default_and_upstream_branches, strip_index_file
+    sync_with_branch, strip_index_file
 )
 from . import constants
 
@@ -1284,7 +1284,7 @@ def save_page(repo, default_branch_name, working_branch_name, file_path, new_val
             repo.git.reset(rebase_commit, hard=True)
             repo.git.branch('-D', tmp_branch_name)
 
-    sync_with_default_and_upstream_branches(repo, working_branch_name)
+    sync_with_branch(repo, working_branch_name, working_branch_name)
 
     repo.git.push('origin', working_branch_name)
 

--- a/chime/views.py
+++ b/chime/views.py
@@ -367,7 +367,7 @@ def branch_modify_category(branch_name, path=u''):
     # delete the passed category
     if 'delete' in request.form:
         # delete the page
-        redirect_path, do_save, commit_message = view_functions.delete_page(repo=repo, browse_path=path, target_path=path)
+        redirect_path, do_save, commit_message = view_functions.delete_page(repo=repo, working_branch_name=branch_name, browse_path=path, target_path=path)
         # save and redirect
         if do_save:
             master_name = current_app.config['default_branch']
@@ -458,7 +458,7 @@ def branch_edit_file(branch_name, path=None):
                 flash(u'Please enter a name to create {}!'.format(describe_what), u'warning')
             return redirect('/tree/{}/edit/{}'.format(safe_branch, file_path), code=303)
 
-        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(repo, create_path, request.form['request_path'], create_what)
+        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(repo, branch_name, create_path, request.form['request_path'], create_what)
         if do_save:
             commit = repo.commit()
             commit_message = add_message
@@ -468,7 +468,7 @@ def branch_edit_file(branch_name, path=None):
             flash(add_message, u'notice')
 
     elif action == 'delete' and 'request_path' in request.form:
-        redirect_path, do_save, commit_message = view_functions.delete_page(repo=repo, browse_path=path, target_path=request.form['request_path'])
+        redirect_path, do_save, commit_message = view_functions.delete_page(repo=repo, working_branch_name=branch_name, browse_path=path, target_path=request.form['request_path'])
         if do_save:
             # flash the human-readable part of the commit message
             flash(u'{}! Remember to submit this change for feedback when you\'re ready to go live.'.format(commit_message.split('\n')[0]), u'notice')

--- a/chime/views.py
+++ b/chime/views.py
@@ -562,6 +562,7 @@ def branch_history(branch_name, path=None):
 
     kwargs = view_functions.common_template_args(current_app.config, session)
     kwargs.update(branch=branch_name, safe_branch=safe_branch,
+    kwargs.update(safe_branch=safe_branch,
                   history=history, path=path, languages=languages,
                   app_authorized=app_authorized, article_edit_path=article_edit_path,
                   activity=activity)

--- a/chime/views.py
+++ b/chime/views.py
@@ -285,7 +285,7 @@ def branch_edit(branch_name, path=None):
 
     # if this is a published branch, redirect to overview
     if repo_functions.get_activity_working_state(repo, current_app.config['default_branch'], safe_branch) == constants.WORKING_STATE_PUBLISHED:
-        return redirect('/tree/{}/'.format(safe_branch))
+        return redirect('/tree/{}/'.format(safe_branch), code=303)
 
     # flash a conflict warning if necessary
     if repo_functions.get_conflict(repo, current_app.config['default_branch']):
@@ -561,7 +561,6 @@ def branch_history(branch_name, path=None):
         history.append(dict(name=name, email=email, date=date, subject=subject))
 
     kwargs = view_functions.common_template_args(current_app.config, session)
-    kwargs.update(branch=branch_name, safe_branch=safe_branch,
     kwargs.update(safe_branch=safe_branch,
                   history=history, path=path, languages=languages,
                   app_authorized=app_authorized, article_edit_path=article_edit_path,

--- a/chime/views.py
+++ b/chime/views.py
@@ -501,13 +501,7 @@ def show_activity_overview(branch_name):
     if repo_functions.get_activity_working_state(repo, current_app.config['default_branch'], safe_branch) == constants.WORKING_STATE_ACTIVE:
         activity = chime_activity.ChimeActivity(repo=repo, branch_name=safe_branch, default_branch_name=current_app.config['default_branch'], actor_email=session.get('email', None))
     else:
-        task_metadata = repo_functions.get_task_metadata_from_tag(clone=repo, working_branch_name=safe_branch)
-        hexsha = repo.tags[safe_branch].tag.hexsha
-        date_updated, last_edited_email = repo.git.log('--format=%ad\t%ae', '--date=relative', '{}^!'.format(hexsha)).split('\t')
-        activity = chime_activity.ChimePublishedActivity(
-            repo=repo, branch_name=safe_branch, default_branch_name=current_app.config['default_branch'],
-            task_metadata=task_metadata, date_updated=date_updated, last_edited_email=last_edited_email
-        )
+        activity = chime_activity.ChimePublishedActivity(repo=repo, branch_name=safe_branch, default_branch_name=current_app.config['default_branch'])
 
     kwargs.update(activity=activity, app_authorized=app_authorized, languages=languages)
 

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -2051,28 +2051,28 @@ class TestApp (TestCase):
             category_cells = category_row.find_all('td')
             self.assertIsNotNone(category_cells[0].find('a'))
             self.assertEqual(category_cells[0].text, category_name)
-            self.assertEqual(category_cells[1].text, u'Category')
+            self.assertEqual(category_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.CATEGORY_LAYOUT].title())
             self.assertEqual(category_cells[2].text, u'Created')
 
             subcategory_row = check_rows.pop()
             subcategory_cells = subcategory_row.find_all('td')
             self.assertIsNotNone(subcategory_cells[0].find('a'))
             self.assertEqual(subcategory_cells[0].text, subcategory_name)
-            self.assertEqual(subcategory_cells[1].text, u'Category')
+            self.assertEqual(subcategory_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.CATEGORY_LAYOUT].title())
             self.assertEqual(subcategory_cells[2].text, u'Created')
 
             article_1_row = check_rows.pop()
             article_1_cells = article_1_row.find_all('td')
             self.assertIsNotNone(article_1_cells[0].find('a'))
             self.assertEqual(article_1_cells[0].text, article_names[0])
-            self.assertEqual(article_1_cells[1].text, u'Article')
+            self.assertEqual(article_1_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.ARTICLE_LAYOUT].title())
             self.assertEqual(article_1_cells[2].text, u'Created, Edited')
 
             article_2_row = check_rows.pop()
             article_2_cells = article_2_row.find_all('td')
             self.assertIsNone(article_2_cells[0].find('a'))
             self.assertEqual(article_2_cells[0].text, article_names[1])
-            self.assertEqual(article_2_cells[1].text, u'Article')
+            self.assertEqual(article_2_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.ARTICLE_LAYOUT].title())
             self.assertEqual(article_2_cells[2].text, u'Created, Deleted')
 
             # only the header row's left

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -1008,9 +1008,8 @@ class TestApp (TestCase):
         branch1_name = branch1.name
         branch1.checkout()
 
-        # verify that the most recent commit on the new branch is for the task metadata file
-        # by checking for the name of the file in the commit message
-        self.assertTrue(repo_functions.TASK_METADATA_FILENAME in branch1.commit.message)
+        # verify that the most recent commit on the new branch is for starting the activity
+        self.assertTrue(repo_functions.ACTIVITY_CREATED_MESSAGE in branch1.commit.message)
 
         # validate the existence of the task metadata file
         self.assertTrue(repo_functions.verify_file_exists_in_branch(self.clone1, repo_functions.TASK_METADATA_FILENAME, branch1_name))

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -1439,7 +1439,7 @@ class TestApp (TestCase):
             repo = view_functions.get_repo(repo_path=self.app.config['REPO_PATH'], work_path=self.app.config['WORK_PATH'], email='erica@example.com')
             activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name='master', actor_email=erica_email)
             activity_history = activity.history
-            delete_history = json.loads(activity_history[0]['commit_body'])['actions']
+            delete_history = activity_history[0]['commit_body']['actions']
             for item in delete_history:
                 self.assertEqual(item['action'], u'delete')
                 if item['title'] in category_names:

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -1439,7 +1439,7 @@ class TestApp (TestCase):
             repo = view_functions.get_repo(repo_path=self.app.config['REPO_PATH'], work_path=self.app.config['WORK_PATH'], email='erica@example.com')
             activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name='master', actor_email=erica_email)
             activity_history = activity.history
-            delete_history = activity_history[0]['commit_body']['actions']
+            delete_history = activity_history[0]['actions']
             for item in delete_history:
                 self.assertEqual(item['action'], u'delete')
                 if item['title'] in category_names:

--- a/test/unit/app.py
+++ b/test/unit/app.py
@@ -1439,7 +1439,7 @@ class TestApp (TestCase):
             repo = view_functions.get_repo(repo_path=self.app.config['REPO_PATH'], work_path=self.app.config['WORK_PATH'], email='erica@example.com')
             activity = chime_activity.ChimeActivity(repo=repo, branch_name=branch_name, default_branch_name='master', actor_email=erica_email)
             activity_history = activity.history
-            delete_history = json.loads(activity_history[0]['commit_body'])
+            delete_history = json.loads(activity_history[0]['commit_body'])['actions']
             for item in delete_history:
                 self.assertEqual(item['action'], u'delete')
                 if item['title'] in category_names:

--- a/test/unit/chime_test_client.py
+++ b/test/unit/chime_test_client.py
@@ -45,13 +45,6 @@ class ChimeTestClient:
 
         self.path, self.soup, self.headers = url, BeautifulSoup(response.data), response.headers
 
-    def open_link_blindly(self, url):
-        ''' Open a link without testing
-        '''
-        response = self.client.get(url)
-
-        self.path, self.soup, self.headers = url, BeautifulSoup(response.data), response.headers
-
     def follow_link(self, href):
         ''' Follow a link after making sure it's present in the page.
         '''

--- a/test/unit/chime_test_client.py
+++ b/test/unit/chime_test_client.py
@@ -43,7 +43,10 @@ class ChimeTestClient:
         response = self.client.get(url)
         self.test.assertEqual(response.status_code, expected_status_code)
 
-        self.path, self.soup, self.headers = url, BeautifulSoup(response.data), response.headers
+        if expected_status_code in range(300, 399):
+            self.follow_redirect(response, expected_status_code)
+        else:
+            self.path, self.soup, self.headers = url, BeautifulSoup(response.data), response.headers
 
     def follow_link(self, href):
         ''' Follow a link after making sure it's present in the page.

--- a/test/unit/process.py
+++ b/test/unit/process.py
@@ -23,7 +23,7 @@ from httmock import response, HTTMock
 from mock import MagicMock
 from bs4 import Comment
 
-from chime import create_app, repo_functions, google_api_functions, view_functions
+from chime import create_app, repo_functions, google_api_functions, view_functions, constants
 
 from unit.chime_test_client import ChimeTestClient
 
@@ -1136,21 +1136,21 @@ class TestProcess (TestCase):
             category_cells = category_row.find_all('td')
             self.assertIsNotNone(category_cells[0].find('a'))
             self.assertEqual(category_cells[0].text, topic_name)
-            self.assertEqual(category_cells[1].text, u'Category')
+            self.assertEqual(category_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.CATEGORY_LAYOUT].title())
             self.assertEqual(category_cells[2].text, u'Created')
 
             subcategory_row = check_rows.pop()
             subcategory_cells = subcategory_row.find_all('td')
             self.assertIsNotNone(subcategory_cells[0].find('a'))
             self.assertEqual(subcategory_cells[0].text, subtopic_name)
-            self.assertEqual(subcategory_cells[1].text, u'Category')
+            self.assertEqual(subcategory_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.CATEGORY_LAYOUT].title())
             self.assertEqual(subcategory_cells[2].text, u'Created')
 
             article_1_row = check_rows.pop()
             article_1_cells = article_1_row.find_all('td')
             self.assertIsNotNone(article_1_cells[0].find('a'))
             self.assertEqual(article_1_cells[0].text, article_name)
-            self.assertEqual(article_1_cells[1].text, u'Article')
+            self.assertEqual(article_1_cells[1].text, constants.LAYOUT_DISPLAY_LOOKUP[constants.ARTICLE_LAYOUT].title())
             self.assertEqual(article_1_cells[2].text, u'Created, Edited')
 
             # only the header row's left

--- a/test/unit/process.py
+++ b/test/unit/process.py
@@ -478,8 +478,9 @@ class TestProcess (TestCase):
             self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'button' and tag['value'] == u'Publish'))
 
     # in TestProcess
-    def test_page_not_found_when_branch_published(self):
-        ''' When you're working in a published branch and don't have a local copy, you get a 404 error
+    def test_redirect_to_overview_when_branch_published(self):
+        ''' When you're working in a published branch and don't have a local copy, you're redirected to
+            that activity's overview page.
         '''
         with HTTMock(self.auth_csv_example_allowed):
             erica_email = u'erica@example.com'
@@ -528,7 +529,7 @@ class TestProcess (TestCase):
             # Switch users
             #
             # load an edit page
-            erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug), expected_status_code=404)
+            erica.open_link(url='/tree/{}/edit/other/{}/'.format(erica_branch_name, category_slug), expected_status_code=303)
             # a warning is flashed about working in a published branch
             # we can't get the date exactly right, so test for every other part of the message
             message_published = view_functions.MESSAGE_ACTIVITY_PUBLISHED.format(published_date=u'xxx', published_by=frances_email)
@@ -536,10 +537,10 @@ class TestProcess (TestCase):
             for part in message_published_split:
                 self.assertIsNotNone(erica.soup.find(lambda tag: tag.name == 'li' and part in tag.text))
 
-            # the 404 page was loaded
+            # the overview page was loaded
             pattern_template_comment_stripped = sub(ur'<!--|-->', u'', PATTERN_TEMPLATE_COMMENT)
             comments = erica.soup.find_all(text=lambda text: isinstance(text, Comment))
-            self.assertTrue(pattern_template_comment_stripped.format(u'error-404') in comments)
+            self.assertTrue(pattern_template_comment_stripped.format(u'activity-overview') in comments)
 
     # in TestProcess
     def test_notified_when_working_in_deleted_task(self):

--- a/test/unit/repo.py
+++ b/test/unit/repo.py
@@ -1075,7 +1075,6 @@ class TestRepo (TestCase):
         redirect_path, do_save, commit_message = view_functions.delete_page(repo=new_clone, working_branch_name=working_branch.name, browse_path=browse_path, target_path=dir_path)
         self.assertEqual(cat_slug.rstrip('/'), redirect_path.rstrip('/'))
         self.assertEqual(True, do_save)
-        self.maxDiff = None
         self.assertEqual(u'The "{cat2_title}" topic (containing 1 article) was deleted\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "delete", "file_path": "{cat2_path}", "display_type": "category", "title": "{cat2_title}"}}, {{"action": "delete", "file_path": "{art_path}", "display_type": "article", "title": "{art_title}"}}]}}'.format(branch_name=working_branch.name, cat2_title=cat2_title, cat2_path=cat2_path, art_path=art_path, art_title=art_title), commit_message)
 
         repo_functions.save_working_file(clone=new_clone, path=dir_path, message=commit_message, base_sha=new_clone.commit().hexsha, default_branch_name='master')

--- a/test/unit/repo.py
+++ b/test/unit/repo.py
@@ -243,12 +243,12 @@ class TestRepo (TestCase):
     def test_try_to_create_existing_category(self):
         ''' We can't create a category that exists already.
         '''
-        first_result = view_functions.add_article_or_category(self.clone1, 'categories', 'My New Category', constants.CATEGORY_LAYOUT)
-        self.assertEqual(u'The "My New Category" topic was created\n\n[{"action": "create", "file_path": "categories/my-new-category/index.markdown", "display_type": "category", "title": "My New Category"}]', first_result[0])
+        first_result = view_functions.add_article_or_category(self.clone1, None, 'categories', 'My New Category', constants.CATEGORY_LAYOUT)
+        self.assertEqual(u'The "My New Category" topic was created\n\n{"branch_name": "master", "actions": [{"action": "create", "file_path": "categories/my-new-category/index.markdown", "display_type": "category", "title": "My New Category"}]}', first_result[0])
         self.assertEqual(u'categories/my-new-category/index.markdown', first_result[1])
         self.assertEqual(u'categories/my-new-category/', first_result[2])
         self.assertEqual(True, first_result[3])
-        second_result = view_functions.add_article_or_category(self.clone1, 'categories', 'My New Category', constants.CATEGORY_LAYOUT)
+        second_result = view_functions.add_article_or_category(self.clone1, None, 'categories', 'My New Category', constants.CATEGORY_LAYOUT)
         self.assertEqual('Topic "My New Category" already exists', second_result[0])
         self.assertEqual(u'categories/my-new-category/index.markdown', second_result[1])
         self.assertEqual(u'categories/my-new-category/', second_result[2])
@@ -258,12 +258,12 @@ class TestRepo (TestCase):
     def test_try_to_create_existing_article(self):
         ''' We can't create an article that exists already
         '''
-        first_result = view_functions.add_article_or_category(self.clone1, 'categories/example', 'New Article', constants.ARTICLE_LAYOUT)
-        self.assertEqual(u'The "New Article" article was created\n\n[{"action": "create", "file_path": "categories/example/new-article/index.markdown", "display_type": "article", "title": "New Article"}]', first_result[0])
+        first_result = view_functions.add_article_or_category(self.clone1, None, 'categories/example', 'New Article', constants.ARTICLE_LAYOUT)
+        self.assertEqual(u'The "New Article" article was created\n\n{"branch_name": "master", "actions": [{"action": "create", "file_path": "categories/example/new-article/index.markdown", "display_type": "article", "title": "New Article"}]}', first_result[0])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
         self.assertEqual(True, first_result[3])
-        second_result = view_functions.add_article_or_category(self.clone1, 'categories/example', 'New Article', constants.ARTICLE_LAYOUT)
+        second_result = view_functions.add_article_or_category(self.clone1, None, 'categories/example', 'New Article', constants.ARTICLE_LAYOUT)
         self.assertEqual('Article "New Article" already exists', second_result[0])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[1])
         self.assertEqual(u'categories/example/new-article/index.markdown', first_result[2])
@@ -275,8 +275,8 @@ class TestRepo (TestCase):
         '''
         category_name = u'Kristen/Melissa/Kate/Leslie'
         category_slug = slugify(category_name)
-        add_result = view_functions.add_article_or_category(self.clone1, 'categories', category_name, constants.CATEGORY_LAYOUT)
-        self.assertEqual(u'The "{category_name}" topic was created\n\n[{{"action": "create", "file_path": "categories/{category_slug}/index.markdown", "display_type": "category", "title": "{category_name}"}}]'.format(category_name=category_name, category_slug=category_slug), add_result[0])
+        add_result = view_functions.add_article_or_category(self.clone1, None, 'categories', category_name, constants.CATEGORY_LAYOUT)
+        self.assertEqual(u'The "{category_name}" topic was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "categories/{category_slug}/index.markdown", "display_type": "category", "title": "{category_name}"}}]}}'.format(branch_name='master', category_name=category_name, category_slug=category_slug), add_result[0])
         self.assertEqual(u'categories/{category_slug}/index.markdown'.format(category_slug=category_slug), add_result[1])
         self.assertEqual(u'categories/{category_slug}/'.format(category_slug=category_slug), add_result[2])
         self.assertEqual(True, add_result[3])
@@ -288,8 +288,8 @@ class TestRepo (TestCase):
         article_name = u'Erin/Abby/Jillian/Patty'
         article_slug = slugify(article_name)
 
-        add_result = view_functions.add_article_or_category(self.clone1, 'categories/example', article_name, constants.ARTICLE_LAYOUT)
-        self.assertEqual(u'The "{article_name}" article was created\n\n[{{"action": "create", "file_path": "categories/example/{article_slug}/index.markdown", "display_type": "article", "title": "{article_name}"}}]'.format(article_name=article_name, article_slug=article_slug), add_result[0])
+        add_result = view_functions.add_article_or_category(self.clone1, None, 'categories/example', article_name, constants.ARTICLE_LAYOUT)
+        self.assertEqual(u'The "{article_name}" article was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "categories/example/{article_slug}/index.markdown", "display_type": "article", "title": "{article_name}"}}]}}'.format(branch_name='master', article_name=article_name, article_slug=article_slug), add_result[0])
         self.assertEqual(u'categories/example/{article_slug}/index.markdown'.format(article_slug=article_slug), add_result[1])
         self.assertEqual(u'categories/example/{article_slug}/index.markdown'.format(article_slug=article_slug), add_result[2])
         self.assertEqual(True, add_result[3])
@@ -924,9 +924,9 @@ class TestRepo (TestCase):
         # create an article
         art_title = u'快速狐狸'
         art_slug = slugify(art_title)
-        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, u'', art_title, constants.ARTICLE_LAYOUT)
+        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, None, u'', art_title, constants.ARTICLE_LAYOUT)
         self.assertEqual(u'{}/index.{}'.format(art_slug, constants.CONTENT_FILE_EXTENSION), file_path)
-        self.assertEqual(u'The "{art_title}" article was created\n\n[{{"action": "create", "file_path": "{file_path}", "display_type": "article", "title": "{art_title}"}}]'.format(art_title=art_title, file_path=file_path), add_message)
+        self.assertEqual(u'The "{art_title}" article was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "article", "title": "{art_title}"}}]}}'.format(branch_name=working_branch.name, art_title=art_title, file_path=file_path), add_message)
         self.assertEqual(u'{}/index.{}'.format(art_slug, constants.CONTENT_FILE_EXTENSION), redirect_path)
         self.assertEqual(True, do_save)
         # commit the article
@@ -963,9 +963,9 @@ class TestRepo (TestCase):
         # create a category
         cat_title = u'快速狐狸'
         cat_slug = slugify(cat_title)
-        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, u'', cat_title, constants.CATEGORY_LAYOUT)
+        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, working_branch.name, u'', cat_title, constants.CATEGORY_LAYOUT)
         self.assertEqual(u'{}/index.{}'.format(cat_slug, constants.CONTENT_FILE_EXTENSION), file_path)
-        self.assertEqual(u'The "{cat_title}" topic was created\n\n[{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]'.format(cat_title=cat_title, file_path=file_path), add_message)
+        self.assertEqual(u'The "{cat_title}" topic was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]}}'.format(branch_name=working_branch.name, cat_title=cat_title, file_path=file_path), add_message)
         self.assertEqual(u'{}/'.format(cat_slug), redirect_path)
         self.assertEqual(True, do_save)
         # commit the category
@@ -1024,9 +1024,9 @@ class TestRepo (TestCase):
         # create a category
         cat_title = u'Daffodils and Drop Cloths'
         cat_slug = slugify(cat_title)
-        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, u'', cat_title, constants.CATEGORY_LAYOUT)
+        add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, working_branch.name, u'', cat_title, constants.CATEGORY_LAYOUT)
         self.assertEqual(u'{}/index.{}'.format(cat_slug, constants.CONTENT_FILE_EXTENSION), file_path)
-        self.assertEqual(u'The "{cat_title}" topic was created\n\n[{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]'.format(cat_title=cat_title, file_path=file_path), add_message)
+        self.assertEqual(u'The "{cat_title}" topic was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]}}'.format(branch_name=working_branch.name, cat_title=cat_title, file_path=file_path), add_message)
         self.assertEqual(u'{}/'.format(cat_slug), redirect_path)
         self.assertEqual(True, do_save)
         # commit the category
@@ -1040,9 +1040,9 @@ class TestRepo (TestCase):
         # create a category inside that
         cat2_title = u'Drain Bawlers'
         cat2_slug = slugify(cat2_title)
-        add_message, cat2_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, cat_slug, cat2_title, constants.CATEGORY_LAYOUT)
+        add_message, cat2_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, working_branch.name, cat_slug, cat2_title, constants.CATEGORY_LAYOUT)
         self.assertEqual(u'{}/{}/index.{}'.format(cat_slug, cat2_slug, constants.CONTENT_FILE_EXTENSION), cat2_path)
-        self.assertEqual(u'The "{cat_title}" topic was created\n\n[{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]'.format(cat_title=cat2_title, file_path=cat2_path), add_message)
+        self.assertEqual(u'The "{cat_title}" topic was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "category", "title": "{cat_title}"}}]}}'.format(branch_name=working_branch.name, cat_title=cat2_title, file_path=cat2_path), add_message)
         self.assertEqual(u'{}/{}/'.format(cat_slug, cat2_slug), redirect_path)
         self.assertEqual(True, do_save)
         # commit the category
@@ -1057,9 +1057,9 @@ class TestRepo (TestCase):
         art_title = u'သံပုရာဖျော်ရည်'
         art_slug = slugify(art_title)
         dir_path = redirect_path.rstrip('/')
-        add_message, art_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, dir_path, art_title, constants.ARTICLE_LAYOUT)
+        add_message, art_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, working_branch.name, dir_path, art_title, constants.ARTICLE_LAYOUT)
         self.assertEqual(u'{}/{}/{}/index.{}'.format(cat_slug, cat2_slug, art_slug, constants.CONTENT_FILE_EXTENSION), art_path)
-        self.assertEqual(u'The "{art_title}" article was created\n\n[{{"action": "create", "file_path": "{file_path}", "display_type": "article", "title": "{art_title}"}}]'.format(art_title=art_title, file_path=art_path), add_message)
+        self.assertEqual(u'The "{art_title}" article was created\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "article", "title": "{art_title}"}}]}}'.format(branch_name=working_branch.name, art_title=art_title, file_path=art_path), add_message)
         self.assertEqual(u'{}/{}/{}/index.{}'.format(cat_slug, cat2_slug, art_slug, constants.CONTENT_FILE_EXTENSION), redirect_path)
         self.assertEqual(True, do_save)
         # commit the article
@@ -1072,10 +1072,11 @@ class TestRepo (TestCase):
 
         # now delete the second category
         browse_path = repo_functions.strip_index_file(art_path)
-        redirect_path, do_save, commit_message = view_functions.delete_page(repo=new_clone, browse_path=browse_path, target_path=dir_path)
+        redirect_path, do_save, commit_message = view_functions.delete_page(repo=new_clone, working_branch_name=working_branch.name, browse_path=browse_path, target_path=dir_path)
         self.assertEqual(cat_slug.rstrip('/'), redirect_path.rstrip('/'))
         self.assertEqual(True, do_save)
-        self.assertEqual(u'The "{cat2_title}" topic (containing 1 article) was deleted\n\n[{{"action": "delete", "file_path": "{cat2_path}", "display_type": "category", "title": "{cat2_title}"}}, {{"action": "delete", "file_path": "{art_path}", "display_type": "article", "title": "{art_title}"}}]'.format(cat2_title=cat2_title, cat2_path=cat2_path, art_path=art_path, art_title=art_title), commit_message)
+        self.maxDiff = None
+        self.assertEqual(u'The "{cat2_title}" topic (containing 1 article) was deleted\n\n{{"branch_name": "{branch_name}", "actions": [{{"action": "delete", "file_path": "{cat2_path}", "display_type": "category", "title": "{cat2_title}"}}, {{"action": "delete", "file_path": "{art_path}", "display_type": "article", "title": "{art_title}"}}]}}'.format(branch_name=working_branch.name, cat2_title=cat2_title, cat2_path=cat2_path, art_path=art_path, art_title=art_title), commit_message)
 
         repo_functions.save_working_file(clone=new_clone, path=dir_path, message=commit_message, base_sha=new_clone.commit().hexsha, default_branch_name='master')
 
@@ -1124,7 +1125,7 @@ class TestRepo (TestCase):
         ]
         updated_details = []
         for detail in create_details:
-            add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, detail[0], detail[1], detail[2])
+            add_message, file_path, redirect_path, do_save = view_functions.add_article_or_category(new_clone, working_branch.name, detail[0], detail[1], detail[2])
             updated_details.append(detail + (file_path,))
             repo_functions.save_working_file(new_clone, file_path, add_message, new_clone.commit().hexsha, 'master')
 
@@ -1137,7 +1138,7 @@ class TestRepo (TestCase):
         repo_functions.provide_feedback(new_clone, newline_comment)
 
         # delete a category with stuff in it
-        commit_message = view_functions.make_delete_display_commit_message(new_clone, 'tree')
+        commit_message = view_functions.make_delete_display_commit_message(new_clone, working_branch.name, 'tree')
         deleted_file_paths, do_save = edit_functions.delete_file(new_clone, 'tree')
         # commit
         repo_functions.save_working_file(new_clone, 'tree', commit_message, new_clone.commit().hexsha, 'master')
@@ -1166,7 +1167,7 @@ class TestRepo (TestCase):
         # check the delete
         check_item = activity_history.pop(0)
         self.assertEqual(u'The "{}" topic (containing 1 topic and 1 article) was deleted'.format(updated_details[0][1]), check_item['commit_subject'])
-        self.assertEqual(u'[{{"action": "delete", "file_path": "{cat1_path}", "display_type": "category", "title": "{cat1_title}"}}, {{"action": "delete", "file_path": "{cat2_path}", "display_type": "category", "title": "{cat2_title}"}}, {{"action": "delete", "file_path": "{art1_path}", "display_type": "article", "title": "{art1_title}"}}]'.format(cat1_path=updated_details[0][3], cat1_title=updated_details[0][1], cat2_path=updated_details[1][3], cat2_title=updated_details[1][1], art1_path=updated_details[2][3], art1_title=updated_details[2][1]), check_item['commit_body'])
+        self.assertEqual(u'{{"branch_name": "{branch_name}", "actions": [{{"action": "delete", "file_path": "{cat1_path}", "display_type": "category", "title": "{cat1_title}"}}, {{"action": "delete", "file_path": "{cat2_path}", "display_type": "category", "title": "{cat2_title}"}}, {{"action": "delete", "file_path": "{art1_path}", "display_type": "article", "title": "{art1_title}"}}]}}'.format(branch_name=working_branch.name, cat1_path=updated_details[0][3], cat1_title=updated_details[0][1], cat2_path=updated_details[1][3], cat2_title=updated_details[1][1], art1_path=updated_details[2][3], art1_title=updated_details[2][1]), check_item['commit_body'])
         self.assertEqual(constants.COMMIT_TYPE_EDIT, check_item['commit_type'])
 
         # check the comments
@@ -1184,7 +1185,7 @@ class TestRepo (TestCase):
         for pos, check_item in list(enumerate(activity_history)):
             check_detail = updated_details[len(updated_details) - (pos + 1)]
             self.assertEqual(u'The "{}" {} was created'.format(check_detail[1], view_functions.file_display_name(check_detail[2])), check_item['commit_subject'])
-            self.assertEqual(u'[{{"action": "create", "file_path": "{file_path}", "display_type": "{display_type}", "title": "{title}"}}]'.format(file_path=check_detail[3], display_type=check_detail[2], title=check_detail[1]), check_item['commit_body'])
+            self.assertEqual(u'{{"branch_name": "{branch_name}", "actions": [{{"action": "create", "file_path": "{file_path}", "display_type": "{display_type}", "title": "{title}"}}]}}'.format(branch_name=working_branch.name, file_path=check_detail[3], display_type=check_detail[2], title=check_detail[1]), check_item['commit_body'])
             self.assertEqual(constants.COMMIT_TYPE_EDIT, check_item['commit_type'])
 
     # in TestRepo
@@ -1236,25 +1237,25 @@ class TestRepo (TestCase):
         ''' Make sure that full folders can be deleted, and that what's reported as deleted matches what's expected.
         '''
         # build some nested categories
-        view_functions.add_article_or_category(self.clone1, '', 'quick', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick', 'brown', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/brown', 'fox', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick', 'red', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick', 'yellow', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/yellow', 'banana', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick', 'orange', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/brown', 'potato', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/yellow', 'lemon', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/red', 'tomato', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/red', 'balloon', constants.CATEGORY_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/orange', 'peanut', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, '', 'quick', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick', 'brown', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/brown', 'fox', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick', 'red', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick', 'yellow', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/yellow', 'banana', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick', 'orange', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/brown', 'potato', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/yellow', 'lemon', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/red', 'tomato', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/red', 'balloon', constants.CATEGORY_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/orange', 'peanut', constants.CATEGORY_LAYOUT)
         # add in some articles
-        view_functions.add_article_or_category(self.clone1, 'quick/brown/fox', 'fur', constants.ARTICLE_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/brown/fox', 'ears', constants.ARTICLE_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/yellow/lemon', 'rind', constants.ARTICLE_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/yellow/lemon', 'pulp', constants.ARTICLE_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/orange/peanut', 'shell', constants.ARTICLE_LAYOUT)
-        view_functions.add_article_or_category(self.clone1, 'quick/red/balloon', 'string', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/brown/fox', 'fur', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/brown/fox', 'ears', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/yellow/lemon', 'rind', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/yellow/lemon', 'pulp', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/orange/peanut', 'shell', constants.ARTICLE_LAYOUT)
+        view_functions.add_article_or_category(self.clone1, None, 'quick/red/balloon', 'string', constants.ARTICLE_LAYOUT)
 
         # add and commit
         self.clone1.index.add(['*'])

--- a/test/unit/repo.py
+++ b/test/unit/repo.py
@@ -787,7 +787,7 @@ class TestRepo (TestCase):
 
         # If goner.md is still around, then the branch wasn't fully abandoned.
         self.assertFalse(exists(join(self.clone2.working_dir, 'goner.md')))
-        self.assertTrue(self.clone2.commit().message.startswith('Abandoned work from'))
+        self.assertTrue(self.clone2.commit().message.startswith(u'The "{}" {}'.format(task_description, repo_functions.ACTIVITY_DELETED_MESSAGE)))
 
     # in TestRepo
     def test_peer_review(self):
@@ -1153,7 +1153,14 @@ class TestRepo (TestCase):
         # check the creation of the activity
         check_item = activity_history.pop()
         self.assertEqual(u'The "{}" activity was started'.format(task_description), check_item['commit_subject'])
-        self.assertEqual(u'Created task metadata file "{}"\nSet author_email to {}\nSet task_description to {}'.format(repo_functions.TASK_METADATA_FILENAME, fake_author_email, task_description), check_item['commit_body'])
+        try:
+            check_task_metadata = json.loads(check_item['commit_body'])
+        except ValueError:
+            raise Exception(u'No valid json in commit body.')
+
+        self.assertEqual(check_task_metadata['author_email'], fake_author_email)
+        self.assertEqual(check_task_metadata['task_description'], task_description)
+        self.assertEqual(check_task_metadata['branch_name'], working_branch.name)
         self.assertEqual(constants.COMMIT_TYPE_ACTIVITY_UPDATE, check_item['commit_type'])
 
         # check the delete
@@ -1280,9 +1287,8 @@ class TestRepo (TestCase):
         branch1_name = branch1.name
         branch1.checkout()
 
-        # verify that the most recent commit on the new branch is for the task metadata file
-        # by checking for the name of the file in the commit message
-        self.assertTrue(repo_functions.TASK_METADATA_FILENAME in branch1.commit.message)
+        # verify that the most recent commit on the new branch is for starting the activity
+        self.assertTrue(repo_functions.ACTIVITY_CREATED_MESSAGE in branch1.commit.message)
 
         # validate the existence of the task metadata file
         task_metadata = repo_functions.get_task_metadata_for_branch(self.clone1, branch1_name)
@@ -1303,9 +1309,8 @@ class TestRepo (TestCase):
         branch1_name = branch1.name
         branch1.checkout()
 
-        # verify that the most recent commit on the new branch is for the task metadata file
-        # by checking for the name of the file in the commit message
-        self.assertTrue(repo_functions.TASK_METADATA_FILENAME in branch1.commit.message)
+        # verify that the most recent commit on the new branch is for starting the activity
+        self.assertTrue(repo_functions.ACTIVITY_CREATED_MESSAGE in branch1.commit.message)
 
         # validate the existence of the task metadata file
         task_metadata = repo_functions.get_task_metadata_for_branch(self.clone1, branch1_name)
@@ -1326,9 +1331,8 @@ class TestRepo (TestCase):
         branch1_name = branch1.name
         branch1.checkout()
 
-        # verify that the most recent commit on the new branch is for the task metadata file
-        # by checking for the name of the file in the commit message
-        self.assertTrue(repo_functions.TASK_METADATA_FILENAME in branch1.commit.message)
+        # verify that the most recent commit on the new branch is for starting the activity
+        self.assertTrue(repo_functions.ACTIVITY_CREATED_MESSAGE in branch1.commit.message)
 
         # validate the existence of the task metadata file
         task_metadata = repo_functions.get_task_metadata_for_branch(self.clone1, branch1_name)

--- a/test/unit/repo.py
+++ b/test/unit/repo.py
@@ -1226,8 +1226,11 @@ class TestRepo (TestCase):
         _, universal_body = repo_functions.get_commit_message_subject_and_body(working_branch.commit)
         _, striking_body = repo_functions.get_commit_message_subject_and_body(working_branch.commit.parents[0])
 
-        self.assertEqual(universal_comment, universal_body)
-        self.assertEqual(striking_comment, striking_body)
+        universal_message = json.loads(universal_body)['message']
+        striking_message = json.loads(striking_body)['message']
+
+        self.assertEqual(universal_comment, universal_message)
+        self.assertEqual(striking_comment, striking_message)
 
     # in TestRepo
     def test_delete_full_folders(self):

--- a/test/unit/test_logs.py
+++ b/test/unit/test_logs.py
@@ -204,10 +204,11 @@ class TestLogger(LogTestCase):
                 erica.sign_in('erica@example.com')
 
         with self.assertLogs('chime.view_functions', level='INFO') as cm:
-            erica.open_link_blindly(url='/nothinghere')
+            erica.open_link(url='/nothinghere', expected_status_code=404)
 
         self.assertEqual(cm.output, ['INFO:chime.view_functions:404: Not Found'])
 
+    # in TestLogger
     def test_logging_failure_format(self):
         from chime.view_functions import log_application_errors
 
@@ -222,7 +223,7 @@ class TestLogger(LogTestCase):
                 erica.sign_in('erica@example.com')
 
         with self.assertLogs('chime.view_functions', level='DEBUG', formatter=ChimeErrorReportFormatter()) as cm:
-            erica.open_link_blindly(url='/fail')
+            erica.open_link(url='/fail', expected_status_code=500)
 
         self.assertEqual(1, len(cm.output))
 


### PR DESCRIPTION
Accurately displays the histories of published activities on their overview pages.

I created a ChimePublishedActivity class, a sub-class of ChimeActivity that collects and parses its history differently.

I re-wrote how commits are structured so that Chime could easily find only the commits related to a specific merged branch. It's also backwards-compatible with the old style of commit.

And I re-wrote and -factored a bunch of code and tests to account for these changes.
