### PR TITLE
commit_sha in a published UserTask points to the publish commit

### DIFF
--- a/chime/storage/user_task.py
+++ b/chime/storage/user_task.py
@@ -175,6 +175,8 @@ class UserTask():
         if pushable is True:
             self._pushed = True
         if pushable is WORKING_STATE_PUBLISHED:
+            # point self.commit_sha to the publish commit
+            self.commit_sha = self.repo.tags[self.task_id].commit.hexsha
             raise UserTaskPublished()
         elif pushable is WORKING_STATE_DELETED:
             raise UserTaskDeleted()

--- a/chime/storage/user_task.py
+++ b/chime/storage/user_task.py
@@ -214,7 +214,7 @@ class UserTask():
             # there are notes attached.
             ref = self.repo.tags[ref].commit.hexsha
         
-        raw = self.repo.git.show('--format=%ae %ad', '--date=relative', ref)
+        raw = self.repo.git.show('--format=%ae %ar', ref)
         email, date = raw.split('\n')[0].split(' ', 1)
 
         return dict(published_date=date, published_by=email)


### PR DESCRIPTION
Some tests (`test_notified_when_saving_article_in_published_activity` and `test_published_branch_not_resurrected_on_save`) were failing because UserTask was reporting the wrong author and date for published tasks. I fixed it by explicitly setting `self.commit_sha` to the hexsha of the tagged publish commit.